### PR TITLE
chore: accept reference doc in /convert/html endpoint

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -246,13 +246,27 @@
         ],
         "requestBody": {
           "content": {
-            "text/html": {
+            "multipart/form-data": {
               "schema": {
-                "type": "string"
+                "properties": {
+                  "html": {
+                    "description": "Required html file",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "template": {
+                    "description": "Optional template file",
+                    "format": "binary",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "html"
+                ],
+                "type": "object"
               }
             }
-          },
-          "description": "input html (must include html and body elements)"
+          }
         },
         "responses": {
           "200": {

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/converter/HtmlToDocxConverter.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/converter/HtmlToDocxConverter.java
@@ -1,5 +1,6 @@
 package ch.sbb.polarion.extension.docx_exporter.converter;
 
+import ch.sbb.polarion.extension.docx_exporter.pandoc.service.PandocServiceConnector;
 import ch.sbb.polarion.extension.generic.regex.RegexMatcher;
 import ch.sbb.polarion.extension.docx_exporter.properties.DocxExporterExtensionConfiguration;
 import ch.sbb.polarion.extension.docx_exporter.settings.LocalizationSettings;
@@ -14,26 +15,29 @@ import org.jetbrains.annotations.VisibleForTesting;
 public class HtmlToDocxConverter {
     private final DocxTemplateProcessor docxTemplateProcessor;
     private final HtmlProcessor htmlProcessor;
+    private final PandocServiceConnector pandocServiceConnector;
 
     public HtmlToDocxConverter() {
         this.docxTemplateProcessor = new DocxTemplateProcessor();
         DocxExporterFileResourceProvider fileResourceProvider = new DocxExporterFileResourceProvider();
         this.htmlProcessor = new HtmlProcessor(fileResourceProvider, new LocalizationSettings(), new HtmlLinksHelper(fileResourceProvider), null);
+        this.pandocServiceConnector = new PandocServiceConnector();
     }
 
     @VisibleForTesting
-    public HtmlToDocxConverter(DocxTemplateProcessor docxTemplateProcessor, HtmlProcessor htmlProcessor) {
+    public HtmlToDocxConverter(DocxTemplateProcessor docxTemplateProcessor, HtmlProcessor htmlProcessor, PandocServiceConnector pandocServiceConnector) {
         this.docxTemplateProcessor = docxTemplateProcessor;
         this.htmlProcessor = htmlProcessor;
+        this.pandocServiceConnector = pandocServiceConnector;
     }
 
-    public byte[] convert(String origHtml) {
+    public byte[] convert(String origHtml, byte[] template) {
         validateHtml(origHtml);
         String html = preprocessHtml(origHtml);
         if (DocxExporterExtensionConfiguration.getInstance().isDebug()) {
             new HtmlLogger().log(origHtml, html, "");
         }
-        return null;
+        return pandocServiceConnector.convertToDocx(origHtml, template);
     }
 
     private void validateHtml(String origHtml) {

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/rest/controller/ConverterApiController.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/rest/controller/ConverterApiController.java
@@ -8,6 +8,7 @@ import ch.sbb.polarion.extension.docx_exporter.converter.DocxConverterJobsServic
 import ch.sbb.polarion.extension.docx_exporter.rest.model.NestedListsCheck;
 import ch.sbb.polarion.extension.docx_exporter.rest.model.conversion.ExportParams;
 import ch.sbb.polarion.extension.docx_exporter.service.DocxExporterPolarionService;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -62,8 +63,8 @@ public class ConverterApiController extends ConverterInternalController {
     }
 
     @Override
-    public Response convertHtmlToPdf(String html, String fileName) {
-        return polarionService.callPrivileged(() -> super.convertHtmlToPdf(html, fileName));
+    public Response convertHtmlToPdf(FormDataBodyPart html, FormDataBodyPart template, String fileName) {
+        return polarionService.callPrivileged(() -> super.convertHtmlToPdf(html, template, fileName));
     }
 
     @Override

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/converter/HtmlToDocxConverterTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/converter/HtmlToDocxConverterTest.java
@@ -127,7 +127,7 @@ class HtmlToDocxConverterTest {
     void shouldThrowIllegalArgumentForMalformedHtml() {
         String html = "<span>example text</span>";
 
-        assertThatThrownBy(() -> htmlToDocxConverter.convert(html))
+        assertThatThrownBy(() -> htmlToDocxConverter.convert(html, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("html is malformed");
     }


### PR DESCRIPTION
### Proposed changes

We must make possible to send a reference docx file to the /convert/html endpoint.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
