### PR TITLE
chore: guava usage removal

### DIFF
--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/MediaUtilsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/MediaUtilsTest.java
@@ -1,6 +1,5 @@
 package ch.sbb.polarion.extension.docx_exporter.util;
 
-import com.google.common.primitives.Bytes;
 import lombok.SneakyThrows;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
@@ -75,7 +74,7 @@ class MediaUtilsTest {
         assertEquals("text/plain", MediaUtils.guessMimeType("noExtension", "text".getBytes()));
 
         assertNull(MediaUtils.guessMimeType("unknownExtensionEmptyContent.unk", emptyArray));
-        assertNull(MediaUtils.guessMimeType("unknownExtensionNonsenseContent.unk", Bytes.toArray(List.of(0, 0, 0, 0, 0))));
+        assertNull(MediaUtils.guessMimeType("unknownExtensionNonsenseContent.unk", new byte[] {0, 0, 0, 0, 0}));
 
         assertTrue(InMemoryAppender.anyMessageContains("Cannot get mime type for the resource: unknownExtensionEmptyContent.unk"));
         assertTrue(InMemoryAppender.anyMessageContains("Cannot get mime type for the resource: unknownExtensionNonsenseContent.unk"));


### PR DESCRIPTION
### Proposed changes

We have to try to remove explicit guice v7.0.0 + guava v.31 usage because of some critical security issues..

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
