### PR TITLE
ci: fix deployment process for GitHub Packages

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -154,18 +154,16 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
           cache: maven
-      - name: 📦 Deploy to Maven Central
-        # This cannot be implemented using deploy:deploy-file
-        # The central-publishing-maven-plugin must be used instead due to specific deployment requirements
-        # Additionally, timeouts are set to 1 hour to avoid issues with the connection to Sonatype Central during deployment
+      - name: 📦 Deploy to GitHub Packages
+        # Releases should only be deployed to GitHub packages when the repo is private
+        # Only snapshots should always be deployed here
+        # if: ${{ needs.build.outputs.is_release == 'false' }}  # Comment out when the repository is public
         run: |
-          mvn --batch-mode -s "${SETTINGS_XML}" clean deploy \
+          mvn --batch-mode -s "${SETTINGS_XML}" deploy \
             -Dmaven.test.skip=true \
-            -P gpg-sign \
-            -P central-publishing \
-            -Dcentral.timeout=3600 \
-            -Dmaven.wagon.http.connectionTimeout=3600000 \
-            -Dmaven.wagon.http.readTimeout=3600000
+            -Dmaven.javadoc.skip=true \
+            -Dmaven.source.skip=true \
+            -P deploy-github-packages
       - name: 📦 Upload assets to GitHub Release
         if: ${{ needs.build.outputs.is_release == 'true' }}
         run: |-


### PR DESCRIPTION
This pull request updates the Maven build workflow to change the deployment target from Maven Central to GitHub Packages. The changes simplify the deployment process and adjust configurations to align with the new target.

Deployment target changes:

* [`.github/workflows/maven-build.yml`](diffhunk://#diff-3666a4bb90aefcffb84f1e981faea3bf4a2b870836765640bc46a0d98b7773f2L157-R166): Changed the deployment step from Maven Central to GitHub Packages. Removed configurations specific to Maven Central (e.g., GPG signing, central publishing plugin, and timeout settings) and added configurations for GitHub Packages deployment.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
