### PR TITLE
fix: all export jobs accessible for any user via /jobs endpoints

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -175,7 +175,7 @@
     },
     "/api/convert": {
       "post": {
-        "operationId": "convertToPdf",
+        "operationId": "convertToDocx",
         "requestBody": {
           "content": {
             "application/json": {

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/converter/DocxConverterJobsService.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/converter/DocxConverterJobsService.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -26,7 +27,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class DocxConverterJobsService {
@@ -80,6 +80,7 @@ public class DocxConverterJobsService {
                 });
         JobDetails jobDetails = JobDetails.builder()
                 .future(asyncConversionJob)
+                .user(securityService.getCurrentUser())
                 .exportParams(exportParams)
                 .startingTime(Instant.now())
                 .jobContext(jobContext).build();
@@ -88,11 +89,7 @@ public class DocxConverterJobsService {
     }
 
     public JobState getJobState(String jobId) {
-        JobDetails jobDetails = jobs.get(jobId);
-        if (jobDetails == null) {
-            throw new NoSuchElementException(String.format(UNKNOWN_JOB_MESSAGE, jobId));
-        }
-        CompletableFuture<byte[]> future = jobDetails.future();
+        CompletableFuture<byte[]> future = getJobDetails(jobId).future();
         return JobState.builder()
                 .isDone(future.isDone())
                 .isCompletedExceptionally(future.isCompletedExceptionally())
@@ -101,11 +98,7 @@ public class DocxConverterJobsService {
     }
 
     public Optional<byte[]> getJobResult(String jobId) {
-        JobDetails jobDetails = jobs.get(jobId);
-        if (jobDetails == null) {
-            throw new NoSuchElementException(String.format(UNKNOWN_JOB_MESSAGE, jobId));
-        }
-        CompletableFuture<byte[]> future = jobDetails.future();
+        CompletableFuture<byte[]> future = getJobDetails(jobId).future();
         if (!future.isDone()) {
             return Optional.empty();
         }
@@ -123,24 +116,17 @@ public class DocxConverterJobsService {
     }
 
     public ExportParams getJobParams(String jobId) {
-        JobDetails jobDetails = jobs.get(jobId);
-        if (jobDetails == null) {
-            throw new NoSuchElementException(String.format(UNKNOWN_JOB_MESSAGE, jobId));
-        }
-        return jobDetails.exportParams;
+        return getJobDetails(jobId).exportParams;
     }
 
     public JobContext getJobContext(String jobId) {
-        JobDetails jobDetails = jobs.get(jobId);
-        if (jobDetails == null) {
-            throw new NoSuchElementException(String.format(UNKNOWN_JOB_MESSAGE, jobId));
-        }
-        return jobDetails.jobContext;
+        return getJobDetails(jobId).jobContext;
     }
 
     public Map<String, JobState> getAllJobsStates() {
-        return jobs.keySet().stream()
-                .collect(Collectors.toMap(Function.identity(), this::getJobState));
+        return jobs.entrySet().stream()
+                .filter(entry -> Objects.equals(entry.getValue().user, securityService.getCurrentUser()))
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> getJobState(entry.getKey())));
     }
 
     public static void cleanupExpiredJobs(int timeout) {
@@ -167,6 +153,7 @@ public class DocxConverterJobsService {
     @Builder
     public record JobDetails(
             CompletableFuture<byte[]> future,
+            String user,
             ExportParams exportParams,
             Instant startingTime,
             JobContext jobContext) {
@@ -183,6 +170,14 @@ public class DocxConverterJobsService {
             boolean isCompletedExceptionally,
             boolean isCancelled,
             String errorMessage) {
+    }
+
+    private JobDetails getJobDetails(String jobId) {
+        JobDetails jobDetails = jobs.get(jobId);
+        if (jobDetails == null || !Objects.equals(jobDetails.user, securityService.getCurrentUser())) {
+            throw new NoSuchElementException(String.format(UNKNOWN_JOB_MESSAGE, jobId));
+        }
+        return jobDetails;
     }
 
     private boolean isJobLogoutRequired() {

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/rest/controller/ConverterApiController.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/rest/controller/ConverterApiController.java
@@ -63,6 +63,16 @@ public class ConverterApiController extends ConverterInternalController {
     }
 
     @Override
+    public Response getAllPdfConverterJobs() {
+        return polarionService.callPrivileged(super::getAllPdfConverterJobs);
+    }
+
+    @Override
+    public Response getTemplate() {
+        return polarionService.callPrivileged(super::getTemplate);
+    }
+
+    @Override
     public Response convertHtmlToPdf(FormDataBodyPart html, FormDataBodyPart template, String fileName) {
         return polarionService.callPrivileged(() -> super.convertHtmlToPdf(html, template, fileName));
     }


### PR DESCRIPTION
Refs: #83

### Proposed changes

User can see and query details of jobs which were created by him only.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [ ] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
