### PR TITLE
fix: add ConfigurationApiController and ConfigurationInternalController to rest api application

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/rest/DocxExporterRestApplication.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/rest/DocxExporterRestApplication.java
@@ -1,5 +1,7 @@
 package ch.sbb.polarion.extension.docx_exporter.rest;
 
+import ch.sbb.polarion.extension.docx_exporter.rest.controller.ConfigurationApiController;
+import ch.sbb.polarion.extension.docx_exporter.rest.controller.ConfigurationInternalController;
 import ch.sbb.polarion.extension.docx_exporter.settings.TemplatesSettings;
 import ch.sbb.polarion.extension.generic.rest.GenericRestApplication;
 import ch.sbb.polarion.extension.generic.settings.NamedSettingsRegistry;
@@ -61,14 +63,16 @@ public class DocxExporterRestApplication extends GenericRestApplication {
     @Override
     protected @NotNull Set<Object> getExtensionControllerSingletons() {
         return Set.of(
+                new CollectionApiController(),
+                new CollectionInternalController(),
+                new ConfigurationApiController(),
+                new ConfigurationInternalController(),
                 new ConverterApiController(),
                 new ConverterInternalController(),
                 new SettingsApiController(),
                 new SettingsInternalController(),
                 new TestRunAttachmentsApiController(),
                 new TestRunAttachmentsInternalController(),
-                new CollectionApiController(),
-                new CollectionInternalController(),
                 new UtilityResourcesApiController(),
                 new UtilityResourcesInternalController()
         );


### PR DESCRIPTION
### Proposed changes

This pull request updates the `DocxExporterRestApplication` class to ensure that the `ConfigurationApiController` and `ConfigurationInternalController` are properly imported and registered as extension controller singletons. This change helps maintain the correct order and completeness of controller registration in the application.

Controller registration improvements:

* Added imports for `ConfigurationApiController` and `ConfigurationInternalController` in `DocxExporterRestApplication.java` to ensure these controllers are available for registration.
* Registered `ConfigurationApiController` and `ConfigurationInternalController` as singletons in the `getExtensionControllerSingletons` method, ensuring they are included and properly ordered in the controller set.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
