### PR TITLE
fix: bump pandoc-service to 1.5.2

### DIFF
--- a/src/main/resources/versions.properties
+++ b/src/main/resources/versions.properties
@@ -1,1 +1,1 @@
-pandoc-service.version=1.5.0
+pandoc-service.version=1.5.2


### PR DESCRIPTION
### Proposed changes

This pull request updates the `pandoc-service` dependency to a newer version in the project configuration.

Dependency update:

* Bumped the `pandoc-service.version` property from `1.5.0` to `1.5.2` in `versions.properties` to use the latest features and fixes.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
