### PR TITLE
fix: fix cross-reference links in body of WorkItems

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessor.java
@@ -60,6 +60,8 @@ public class HtmlProcessor {
     private static final String URL_PROJECT_ID_PREFIX = "/polarion/#/project/";
     private static final String URL_WORK_ITEM_ID_PREFIX = "workitem?id=";
     private static final String POLARION_URL_MARKER = "/polarion/#";
+    private static final String WIKI_PATH_PREFIX = "wiki/";
+    private static final String WORK_ITEM_ID_IN_WIKI_PATH_PREFIX = "?selection=";
     private static final String ROWSPAN_ATTR = "rowspan";
     private static final String RIGHT_ALIGNMENT_MARGIN = "auto 0px auto auto";
     private static final String TABLE_OF_FIGURES_ANCHOR_ID_PREFIX = "dlecaption_";
@@ -596,7 +598,7 @@ public class HtmlProcessor {
 
             String afterProject = substringAfter(href, URL_PROJECT_ID_PREFIX);
             String projectId = substringBefore(afterProject, "/", false);
-            String workItemId = substringAfter(afterProject, URL_WORK_ITEM_ID_PREFIX);
+            String workItemId = extractWorkItemId(afterProject);
 
             if (afterProject == null || projectId == null || workItemId == null) {
                 continue;
@@ -610,6 +612,16 @@ public class HtmlProcessor {
                     link.attr(HtmlTagAttr.HREF, "#" + expectedAnchorId);
                 }
             }
+        }
+    }
+
+    private String extractWorkItemId(@Nullable String afterProject) {
+        String workItemId = substringAfter(afterProject, URL_WORK_ITEM_ID_PREFIX);
+        if (workItemId != null) {
+            return workItemId;
+        } else {
+            String wikiPath = substringAfter(afterProject, WIKI_PATH_PREFIX);
+            return substringAfter(wikiPath, WORK_ITEM_ID_IN_WIKI_PATH_PREFIX);
         }
     }
 

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessorTest.java
@@ -114,6 +114,12 @@ class HtmlProcessorTest {
         processor.rewritePolarionUrls(document);
         assertEquals(expected, document.body().html());
 
+        String wikiLink = "<a href=\"http://localhost/polarion/#/project/testProject/wiki/Specification/LinkedWorkItems?selection=12345\">Work Item 12345</a>";
+        String htmlWithWikiAnchor = anchor + wikiLink;
+        document = JSoupUtils.parseHtml(htmlWithWikiAnchor);
+        processor.rewritePolarionUrls(document);
+        assertEquals(expected, document.body().html());
+
         document = JSoupUtils.parseHtml(link);
         processor.rewritePolarionUrls(document);
         assertEquals(link, document.body().html());

--- a/src/test/resources/linkedWorkItemsAfterProcessing.html
+++ b/src/test/resources/linkedWorkItemsAfterProcessing.html
@@ -23,7 +23,7 @@
                         <span class="polarion-no-style-cleanup" title="Parent - child relationship used to structure items.">has parent</span>
                     </div>:
                     <span class="polarion-no-style-cleanup" style="white-space:nowrap;" title="EL-3451 - LinkedWorkItems">
-                        <a style="font-size:1em;" target="_top" class="polarion-Hyperlink" href="http://localhost/polarion/#/project/elibrary/wiki/Specification/LinkedWorkItems?selection=EL-3451">
+                        <a style="font-size:1em;" target="_top" class="polarion-Hyperlink" href="#work-item-anchor-elibrary/EL-3451">
                             <span style="white-space:nowrap;">
                                 <img src="http://localhost/polarion/icons/default/enums/type_heading.png" class="polarion-Icons" onmousedown="return false;" contenteditable="false"/>
                             </span>
@@ -58,7 +58,7 @@
                         <span class="polarion-no-style-cleanup" title="Parent - child relationship used to structure items.">has parent</span>
                     </div>:
                     <span class="polarion-no-style-cleanup" style="white-space:nowrap;" title="EL-3451 - LinkedWorkItems">
-                        <a style="font-size:1em;" target="_top" class="polarion-Hyperlink" href="http://localhost/polarion/#/project/elibrary/wiki/Specification/LinkedWorkItems?selection=EL-3451">
+                        <a style="font-size:1em;" target="_top" class="polarion-Hyperlink" href="#work-item-anchor-elibrary/EL-3451">
                             <span style="white-space:nowrap;">
                                 <img src="http://localhost/polarion/icons/default/enums/type_heading.png" class="polarion-Icons" onmousedown="return false;" contenteditable="false"/>
                             </span>

--- a/src/test/resources/linkedWorkItemsTableAfterProcessing.html
+++ b/src/test/resources/linkedWorkItemsTableAfterProcessing.html
@@ -26,7 +26,7 @@
                     </div>
                     :
                     <span class="polarion-no-style-cleanup" style="white-space:nowrap;" title="EL-3451 - LinkedWorkItems">
-                        <a style="font-size:1em;" target="_top" class="polarion-Hyperlink" href="http://localhost/polarion/#/project/elibrary/wiki/Specification/LinkedWorkItems?selection=EL-3451">
+                        <a style="font-size:1em;" target="_top" class="polarion-Hyperlink" href="#work-item-anchor-elibrary/EL-3451">
                             <span style="white-space:nowrap;">
                                 <img src="http://localhost/polarion/icons/default/enums/type_heading.png" class="polarion-Icons" onmousedown="return false;" contenteditable="false"/>
                             </span>
@@ -63,7 +63,7 @@
                     </div>
                     :
                     <span class="polarion-no-style-cleanup" style="white-space:nowrap;" title="EL-3451 - LinkedWorkItems">
-                        <a style="font-size:1em;" target="_top" class="polarion-Hyperlink" href="http://localhost/polarion/#/project/elibrary/wiki/Specification/LinkedWorkItems?selection=EL-3451">
+                        <a style="font-size:1em;" target="_top" class="polarion-Hyperlink" href="#work-item-anchor-elibrary/EL-3451">
                             <span style="white-space:nowrap;">
                                 <img src="http://localhost/polarion/icons/default/enums/type_heading.png" class="polarion-Icons" onmousedown="return false;" contenteditable="false"/>
                             </span>


### PR DESCRIPTION
Fixes: #163

### Proposed changes

Cross-reference links inserted in body (description) of WorkItems were not replaced by in-document links. This change fixes the issue.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
