### PR TITLE
fix: support for Polarion LaTeX formulas to native Word math

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -155,6 +155,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -203,6 +204,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessor.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Comment;
+import org.jsoup.nodes.DataNode;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
@@ -801,7 +802,10 @@ public class HtmlProcessor {
             // Polarion marks block formulas with data-inline="false"; inline formulas have no data-inline attribute at all.
             boolean display = "false".equals(img.attr("data-inline"));
             Element script = new Element("script").attr("type", display ? "math/tex; mode=display" : "math/tex");
-            script.text(latex);
+            // DataNode keeps the LaTeX source unescaped when serialized. Using script.text(latex) would HTML-escape characters
+            // like '&' (used as the column separator in aligned/array environments) into '&amp;', which Pandoc then receives
+            // literally and fails to parse as LaTeX.
+            script.appendChild(new DataNode(latex));
             // Word renders <m:oMath> as centered "display-style" whenever it is the only content in its <w:p>. For an inline
             // formula we want it anchored to the baseline next to surrounding text, so prepend a zero-width space that
             // becomes an empty <w:r> in the paragraph and forces Word's inline rendering path.

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessor.java
@@ -142,6 +142,11 @@ public class HtmlProcessor {
         // this here, moving such rows also in thead
         timedIfNotNull(generationLog, "Fix table head rowspan", () -> fixTableHeadRowspan(document));
 
+        // Polarion renders LaTeX formulas as <img class="polarion-rte-formula" data-source="..."> with MathJax-rendered SVG in src.
+        // Pandoc's HTML reader doesn't understand that structure and drops the content. Convert the img into
+        // <script type="math/tex[; mode=display]">LATEX</script>, which Pandoc maps to native Word math (OMML).
+        timedIfNotNull(generationLog, "Convert Polarion formulas", () -> convertPolarionFormulas(document));
+
         // Images with styles and "display: block" are searched here. For such images we do following: wrap them into div with text-align style
         // and value "right" if image margin is "auto 0px auto auto" or "center" otherwise.
         timedIfNotNull(generationLog, "Adjust image alignment", () -> adjustImageAlignment(document));
@@ -784,6 +789,26 @@ public class HtmlProcessor {
                     parent.remove();
                 }
             }
+        }
+    }
+
+    public void convertPolarionFormulas(@NotNull Document document) {
+        for (Element img : document.select("img.polarion-rte-formula[data-source]")) {
+            String latex = img.attr("data-source");
+            if (latex.isEmpty()) {
+                continue;
+            }
+            // Polarion marks block formulas with data-inline="false"; inline formulas have no data-inline attribute at all.
+            boolean display = "false".equals(img.attr("data-inline"));
+            Element script = new Element("script").attr("type", display ? "math/tex; mode=display" : "math/tex");
+            script.text(latex);
+            // Word renders <m:oMath> as centered "display-style" whenever it is the only content in its <w:p>. For an inline
+            // formula we want it anchored to the baseline next to surrounding text, so prepend a zero-width space that
+            // becomes an empty <w:r> in the paragraph and forces Word's inline rendering path.
+            if (!display) {
+                img.before(new TextNode("\u200B"));
+            }
+            img.replaceWith(script);
         }
     }
 

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/pandoc/FormulaTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/pandoc/FormulaTest.java
@@ -23,7 +23,8 @@ class FormulaTest extends BasePandocTest {
     void polarionFormulaImagesAreConvertedToNativeWordMath() throws Exception {
         String polarionHtml = readHtmlResource("testFormula");
 
-        // Run the Polarion-formula → Pandoc-math-span transformation exactly as the production pipeline does.
+        // Apply only the Polarion-formula → Pandoc-math-script conversion step. We intentionally bypass the rest of
+        // HtmlProcessor.processHtmlForExport here to keep this test focused on the formula conversion + Pandoc behaviour.
         Document document = JSoupUtils.parseHtml(polarionHtml);
         new HtmlProcessor(null, null, null).convertPolarionFormulas(document);
         String preparedHtml = document.outerHtml();

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/pandoc/FormulaTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/pandoc/FormulaTest.java
@@ -1,0 +1,47 @@
+package ch.sbb.polarion.extension.docx_exporter.pandoc;
+
+import ch.sbb.polarion.extension.docx_exporter.pandoc.service.model.PandocParams;
+import ch.sbb.polarion.extension.docx_exporter.util.HtmlProcessor;
+import ch.sbb.polarion.extension.docx_exporter.util.JSoupUtils;
+import org.docx4j.XmlUtils;
+import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
+import org.docx4j.openpackaging.parts.WordprocessingML.MainDocumentPart;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SkipTestWhenParamNotSet
+class FormulaTest extends BasePandocTest {
+
+    @Test
+    void polarionFormulaImagesAreConvertedToNativeWordMath() throws Exception {
+        String polarionHtml = readHtmlResource("testFormula");
+
+        // Run the Polarion-formula → Pandoc-math-span transformation exactly as the production pipeline does.
+        Document document = JSoupUtils.parseHtml(polarionHtml);
+        new HtmlProcessor(null, null, null).convertPolarionFormulas(document);
+        String preparedHtml = document.outerHtml();
+
+        byte[] docBytes = exportToDOCX(preparedHtml, readTemplate("reference_template"), PandocParams.builder().build());
+        assertNotNull(docBytes);
+        writeReportDocx("polarionFormulaImagesAreConvertedToNativeWordMath_generated", docBytes);
+
+        WordprocessingMLPackage pkg = WordprocessingMLPackage.load(new ByteArrayInputStream(docBytes));
+        MainDocumentPart documentPart = pkg.getMainDocumentPart();
+
+        List<Object> oMathNodes = documentPart.getJAXBNodesViaXPath("//m:oMath", true);
+        assertFalse(oMathNodes.isEmpty(), "Expected at least one <m:oMath> in the generated DOCX");
+        assertTrue(oMathNodes.size() >= 2, "Expected both inline and display formulas to produce <m:oMath> elements, got " + oMathNodes.size());
+
+        // Verify the LaTeX actually reached the DOCX as math, not as plain text / dropped content.
+        String documentXml = XmlUtils.marshaltoString(documentPart.getJaxbElement(), true, true);
+        assertTrue(documentXml.contains("<m:oMath"), "document.xml should contain <m:oMath> elements");
+        assertFalse(documentXml.contains("polarion-rte-formula"), "No residual Polarion formula markers should remain in the DOCX");
+    }
+}

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessorTest.java
@@ -213,6 +213,25 @@ class HtmlProcessorTest {
     }
 
     @Test
+    void convertPolarionFormulasPreservesSpecialCharactersRawTest() {
+        // LaTeX uses '<' and '>' as comparison operators, and '&' as the column separator in aligned/array environments.
+        // All three must reach Pandoc raw; Pandoc reads <script type="math/tex"> as HTML raw text and does not decode entities,
+        // so the HTML-escaped forms '&lt;' / '&gt;' / '&amp;' would end up as literal characters and break the math.
+        String latex = "a < b \\text{ and } c > d \\text{ with } x &= y";
+        String attrValue = latex.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+        String html = "<p><img class=\"polarion-rte-formula\" data-inline=\"false\" data-source=\"" + attrValue + "\"></p>";
+
+        Document document = JSoupUtils.parseHtml(html);
+        processor.convertPolarionFormulas(document);
+
+        String serialized = document.body().html();
+        int scriptStart = serialized.indexOf(">", serialized.indexOf("<script")) + 1;
+        int scriptEnd = serialized.indexOf("</script>");
+        String scriptBody = serialized.substring(scriptStart, scriptEnd);
+        assertEquals(latex, scriptBody, "Expected raw LaTeX (no HTML-escaped entities) inside the script body, got: " + scriptBody);
+    }
+
+    @Test
     void convertPolarionFormulasKeepsOtherImagesAndFormulasWithoutSourceTest() {
         String html = "<p><img src=\"data:image/png;base64,ZHVtbXk=\" />" +
                 "<img class=\"polarion-rte-formula\" src=\"data:image/svg+xml;base64,ZHVtbXk=\" /></p>";

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessorTest.java
@@ -183,6 +183,47 @@ class HtmlProcessorTest {
     }
 
     @Test
+    void convertPolarionFormulasDisplayTest() {
+        String latex = "\\left(\\frac{a}{b+c}\\right)^{2}";
+        String html = "<p>before <img class=\"polarion-rte-formula\" src=\"data:image/svg+xml;base64,ZHVtbXk=\" data-inline=\"false\" data-source=\"" + latex + "\"> after</p>";
+
+        Document document = JSoupUtils.parseHtml(html);
+        processor.convertPolarionFormulas(document);
+
+        assertEquals(
+                "<p>before <script type=\"math/tex; mode=display\">" + latex + "</script> after</p>",
+                document.body().html()
+        );
+    }
+
+    @Test
+    void convertPolarionFormulasInlineTest() {
+        // Polarion omits data-inline for inline formulas; the attribute is only emitted (as "false") for display formulas.
+        String latex = "x^{2} + y^{2}";
+        String html = "<p>before <img class=\"polarion-rte-formula\" src=\"data:image/svg+xml;base64,ZHVtbXk=\" data-source=\"" + latex + "\"> after</p>";
+
+        Document document = JSoupUtils.parseHtml(html);
+        processor.convertPolarionFormulas(document);
+
+        // A zero-width space is prepended to the script tag so Word renders the formula as true inline math.
+        assertEquals(
+                "<p>before \u200B<script type=\"math/tex\">" + latex + "</script> after</p>",
+                document.body().html()
+        );
+    }
+
+    @Test
+    void convertPolarionFormulasKeepsOtherImagesAndFormulasWithoutSourceTest() {
+        String html = "<p><img src=\"data:image/png;base64,ZHVtbXk=\" />" +
+                "<img class=\"polarion-rte-formula\" src=\"data:image/svg+xml;base64,ZHVtbXk=\" /></p>";
+
+        Document document = JSoupUtils.parseHtml(html);
+        processor.convertPolarionFormulas(document);
+
+        assertEquals(html, document.body().html());
+    }
+
+    @Test
     @SneakyThrows
     void adjustImageAlignmentTest() {
         try (InputStream isInvalidHtml = this.getClass().getResourceAsStream("/imageAlignmentBeforeProcessing.html");

--- a/src/test/resources/pandoc/html/testFormula.html
+++ b/src/test/resources/pandoc/html/testFormula.html
@@ -1,0 +1,9 @@
+<html>
+<head><title>Formula Test</title></head>
+<body>
+<p>Inline formula in a sentence: <img class="polarion-rte-formula" src="data:image/svg+xml;base64,ZHVtbXk=" style="width: 7.439ex; height: 2.843ex; vertical-align: -0.671ex;" data-source="x^{2} + y^{2}" /> &mdash; end of line.</p>
+<p>Block formula below:</p>
+<img class="polarion-rte-formula" src="data:image/svg+xml;base64,ZHVtbXk=" style="width: 10.156ex; height: 6.509ex; vertical-align: -2.505ex; display: block; padding: 5px 0px; margin-left: auto; margin-right: auto;" data-inline="false" data-source="\left(\frac{a}{b+c}\right)^{2}" />
+<p>After block.</p>
+</body>
+</html>


### PR DESCRIPTION
### Proposed changes

This pull request adds support for converting Polarion formula images into native Word math objects during DOCX export. The main focus is to ensure that LaTeX formulas rendered as images in Polarion are correctly transformed so that Pandoc and Word can interpret and display them as mathematical equations. Comprehensive tests are also introduced to verify this functionality.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
