### PR TITLE
feat: Add specification of direction of links – incoming, outgoing, both

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1603,6 +1603,16 @@
             "description": "Language in the exported document",
             "type": "string"
           },
+          "linkRoleDirection": {
+            "default": "BOTH",
+            "description": "Direction of selected link roles to include",
+            "enum": [
+              "BOTH",
+              "DIRECT",
+              "REVERSE"
+            ],
+            "type": "string"
+          },
           "linkedWorkitemRoles": {
             "description": "Specific Workitem roles",
             "example": [

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/DocxExportFunction.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/DocxExportFunction.java
@@ -1,5 +1,6 @@
 package ch.sbb.polarion.extension.docx_exporter;
 
+import ch.sbb.polarion.extension.docx_exporter.rest.model.conversion.LinkRoleDirection;
 import ch.sbb.polarion.extension.generic.exception.ObjectNotFoundException;
 import ch.sbb.polarion.extension.generic.settings.NamedSettingsRegistry;
 import ch.sbb.polarion.extension.generic.settings.SettingId;
@@ -115,6 +116,7 @@ public class DocxExportFunction implements IFunction<IModule> {
                 .chapters(stylePackage.getSpecificChapters() == null ? null : List.of(stylePackage.getSpecificChapters().split(",")))
                 .language(stylePackage.getLanguage())
                 .linkedWorkitemRoles(stylePackage.getLinkedWorkitemRoles())
+                .linkRoleDirection(stylePackage.getLinkRoleDirection() != null ? LinkRoleDirection.valueOf(stylePackage.getLinkRoleDirection()) : LinkRoleDirection.BOTH)
                 .build();
     }
 

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/DocxExportFunction.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/DocxExportFunction.java
@@ -19,6 +19,7 @@ import com.polarion.alm.tracker.model.ipi.IInternalBaselinesManager;
 import com.polarion.alm.tracker.workflow.IArguments;
 import com.polarion.alm.tracker.workflow.ICallContext;
 import com.polarion.alm.tracker.workflow.IFunction;
+import com.polarion.core.util.StringUtils;
 import com.polarion.core.util.exceptions.UserFriendlyRuntimeException;
 import com.polarion.core.util.types.Text;
 import com.polarion.platform.persistence.IEnumOption;
@@ -116,8 +117,16 @@ public class DocxExportFunction implements IFunction<IModule> {
                 .chapters(stylePackage.getSpecificChapters() == null ? null : List.of(stylePackage.getSpecificChapters().split(",")))
                 .language(stylePackage.getLanguage())
                 .linkedWorkitemRoles(stylePackage.getLinkedWorkitemRoles())
-                .linkRoleDirection(stylePackage.getLinkRoleDirection() != null ? LinkRoleDirection.valueOf(stylePackage.getLinkRoleDirection()) : LinkRoleDirection.BOTH)
+                .linkRoleDirection(safeParseLinkRoleDirection(stylePackage.getLinkRoleDirection()))
                 .build();
+    }
+
+    private LinkRoleDirection safeParseLinkRoleDirection(String linkRoleDirection) {
+        try {
+            return StringUtils.isEmpty(linkRoleDirection) ? LinkRoleDirection.BOTH : LinkRoleDirection.valueOf(linkRoleDirection);
+        } catch (Exception e) {
+            return LinkRoleDirection.BOTH;
+        }
     }
 
     @VisibleForTesting

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/DocxExporterFormExtension.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/DocxExporterFormExtension.java
@@ -8,6 +8,7 @@ import ch.sbb.polarion.extension.generic.settings.SettingName;
 import ch.sbb.polarion.extension.generic.util.ScopeUtils;
 import ch.sbb.polarion.extension.docx_exporter.properties.DocxExporterExtensionConfiguration;
 import ch.sbb.polarion.extension.docx_exporter.rest.model.conversion.ExportParams;
+import ch.sbb.polarion.extension.docx_exporter.rest.model.conversion.LinkRoleDirection;
 import ch.sbb.polarion.extension.docx_exporter.rest.model.settings.localization.Language;
 import ch.sbb.polarion.extension.docx_exporter.rest.model.settings.stylepackage.DocIdentifier;
 import ch.sbb.polarion.extension.docx_exporter.rest.model.settings.stylepackage.StylePackageModel;
@@ -250,12 +251,17 @@ public class DocxExporterFormExtension implements IFormExtension {
         return form.replace("{DOCUMENT_LANGUAGE}", documentLanguage);
     }
 
-    private String adjustLinkRoles(@NotNull String form, @NotNull List<String> roleEnumValues, @NotNull StylePackageModel stylePackage) {
+    @VisibleForTesting
+    String adjustLinkRoles(@NotNull String form, @NotNull List<String> roleEnumValues, @NotNull StylePackageModel stylePackage) {
         if (!roleEnumValues.isEmpty()) {
             if (!CollectionUtils.isEmpty(stylePackage.getLinkedWorkitemRoles())) {
                 form = form.replace("<input id='docx-selected-roles'", "<input id='docx-selected-roles' checked");
-                form = form.replace("id='docx-roles-wrapper' style='display: none'", "id='docx-roles-wrapper'");
+                form = form.replace("id='docx-roles-wrapper' style='display: none;", "id='docx-roles-wrapper' style='display: flex;");
             }
+
+
+            String linkRoleDirectionToPreselect = stylePackage.getLinkRoleDirection() != null ? stylePackage.getLinkRoleDirection() : LinkRoleDirection.BOTH.toString();
+            form = form.replace(String.format(OPTION_VALUE, linkRoleDirectionToPreselect), String.format(OPTION_SELECTED, linkRoleDirectionToPreselect));
 
             String rolesOptions = roleEnumValues.stream()
                     .map(roleEnumValue -> String.format(OPTION_TEMPLATE,

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/converter/DocxConverter.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/converter/DocxConverter.java
@@ -4,6 +4,7 @@ import ch.sbb.polarion.extension.docx_exporter.pandoc.service.PandocServiceConne
 import ch.sbb.polarion.extension.docx_exporter.pandoc.service.model.PandocParams;
 import ch.sbb.polarion.extension.docx_exporter.properties.DocxExporterExtensionConfiguration;
 import ch.sbb.polarion.extension.docx_exporter.rest.model.conversion.ExportParams;
+import ch.sbb.polarion.extension.docx_exporter.rest.model.conversion.LinkRoleDirection;
 import ch.sbb.polarion.extension.docx_exporter.rest.model.documents.DocumentData;
 import ch.sbb.polarion.extension.docx_exporter.rest.model.settings.templates.TemplatesModel;
 import ch.sbb.polarion.extension.docx_exporter.rest.model.settings.webhooks.AuthType;
@@ -266,7 +267,7 @@ public class DocxConverter {
 
     String postProcessDocumentContent(@NotNull ExportParams exportParams, @Nullable ITrackerProject project, @Nullable String documentContent, @Nullable DocxGenerationLog generationLog) {
         if (documentContent != null) {
-            List<String> selectedRoleEnumValues = project == null ? Collections.emptyList() : EnumValuesProvider.getBidirectionalLinkRoleNames(project, exportParams.getLinkedWorkitemRoles());
+            List<String> selectedRoleEnumValues = project == null ? Collections.emptyList() : EnumValuesProvider.getLinkRoleNames(project, exportParams.getLinkedWorkitemRoles(), exportParams.getLinkRoleDirection());
             return htmlProcessor.processHtmlForExport(documentContent, exportParams, selectedRoleEnumValues, generationLog);
         } else {
             return "";

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/rest/model/conversion/ExportParams.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/rest/model/conversion/ExportParams.java
@@ -66,6 +66,9 @@ public class ExportParams {
     @Schema(description = "Specific Workitem roles", example = "[\"has parent\", \"depends on\"]")
     private List<String> linkedWorkitemRoles;
 
+    @Schema(description = "Direction of selected link roles to include", defaultValue = "BOTH")
+    private LinkRoleDirection linkRoleDirection;
+
     @Schema(description = "Target file name of exported document")
     private String fileName;
 

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/rest/model/conversion/LinkRoleDirection.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/rest/model/conversion/LinkRoleDirection.java
@@ -1,0 +1,7 @@
+package ch.sbb.polarion.extension.docx_exporter.rest.model.conversion;
+
+public enum LinkRoleDirection {
+    BOTH,
+    DIRECT,
+    REVERSE
+}

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/rest/model/settings/stylepackage/StylePackageModel.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/rest/model/settings/stylepackage/StylePackageModel.java
@@ -43,6 +43,7 @@ public class StylePackageModel extends SettingsModel {
     private static final String CUSTOM_NUMBERED_LIST_STYLES_ENTRY_NAME = "CUSTOM NUMBERED LIST STYLES";
     private static final String LANGUAGE_ENTRY_NAME = "LANGUAGE";
     private static final String LINKED_WORKITEM_ROLES_ENTRY_NAME = "LINKED WORKITEM ROLES";
+    private static final String LINK_ROLE_DIRECTION_ENTRY_NAME = "LINK ROLE DIRECTION";
     private static final String ATTACHMENTS_FILTER = "ATTACHMENTS_FILTER";
     private static final String TOC_ENTRY_NAME = "TOC";
 
@@ -63,6 +64,7 @@ public class StylePackageModel extends SettingsModel {
     private String specificChapters;
     private String language;
     private List<String> linkedWorkitemRoles;
+    private String linkRoleDirection;
 
     @Override
     protected String serializeModelData() {
@@ -81,7 +83,8 @@ public class StylePackageModel extends SettingsModel {
                 serializeEntry(CUT_LOCAL_URLS_ENTRY_NAME, cutLocalURLs) +
                 serializeEntry(SPECIFIC_CHAPTERS_ENTRY_NAME, specificChapters) +
                 serializeEntry(LANGUAGE_ENTRY_NAME, language) +
-                serializeEntry(LINKED_WORKITEM_ROLES_ENTRY_NAME, linkedWorkitemRoles);
+                serializeEntry(LINKED_WORKITEM_ROLES_ENTRY_NAME, linkedWorkitemRoles) +
+                serializeEntry(LINK_ROLE_DIRECTION_ENTRY_NAME, linkRoleDirection);
 
     }
 
@@ -104,6 +107,7 @@ public class StylePackageModel extends SettingsModel {
         specificChapters = deserializeEntry(SPECIFIC_CHAPTERS_ENTRY_NAME, serializedString);
         language = deserializeEntry(LANGUAGE_ENTRY_NAME, serializedString);
         linkedWorkitemRoles = deserializeListEntry(LINKED_WORKITEM_ROLES_ENTRY_NAME, serializedString, String.class);
+        linkRoleDirection = deserializeEntry(LINK_ROLE_DIRECTION_ENTRY_NAME, serializedString);
     }
 
     private CommentsRenderType parseRenderComments(String value) {

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/EnumValuesProvider.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/EnumValuesProvider.java
@@ -1,5 +1,6 @@
 package ch.sbb.polarion.extension.docx_exporter.util;
 
+import ch.sbb.polarion.extension.docx_exporter.rest.model.conversion.LinkRoleDirection;
 import com.polarion.alm.tracker.model.ILinkRoleOpt;
 import com.polarion.alm.tracker.model.ITrackerProject;
 import com.polarion.alm.tracker.model.ITypeOpt;
@@ -29,13 +30,18 @@ public final class EnumValuesProvider {
     }
 
     @NotNull
-    public static List<String> getBidirectionalLinkRoleNames(@NotNull ITrackerProject trackerProject, @Nullable List<String> directRoleNames) {
-        if (directRoleNames != null && !directRoleNames.isEmpty()) {
+    public static List<String> getLinkRoleNames(@NotNull ITrackerProject trackerProject, @Nullable List<String> selectedRoleNames, @Nullable LinkRoleDirection direction) {
+        if (selectedRoleNames != null && !selectedRoleNames.isEmpty()) {
+            LinkRoleDirection effectiveDirection = direction == null ? LinkRoleDirection.BOTH : direction;
             List<ITypeOpt> wiTypes = trackerProject.getWorkItemTypeEnum().getAllOptions();
             final List<ILinkRoleOpt> linkRoles = getLinkRoles(trackerProject, wiTypes);
             return linkRoles.stream()
-                    .filter(linkRole -> directRoleNames.contains(linkRole.getName()))
-                    .flatMap(linkRole -> Stream.of(linkRole.getName(), linkRole.getOppositeName()))
+                    .filter(linkRole -> selectedRoleNames.contains(linkRole.getName()))
+                    .flatMap(linkRole -> switch (effectiveDirection) {
+                        case DIRECT -> Stream.of(linkRole.getName());
+                        case REVERSE -> Stream.of(linkRole.getOppositeName());
+                        case BOTH -> Stream.of(linkRole.getName(), linkRole.getOppositeName());
+                    })
                     .toList();
         } else {
             return Collections.emptyList();

--- a/src/main/resources/webapp/docx-exporter-admin/js/modules/style-packages.js
+++ b/src/main/resources/webapp/docx-exporter-admin/js/modules/style-packages.js
@@ -128,6 +128,18 @@ const RenderComments = {
     }
 }
 
+const LinkRoleDirection = {
+    linkRoleDirectionSelect: new CustomSelect({
+        selectContainer: ctx.getElementById("link-role-direction-select")
+    }),
+
+    init: function () {
+        this.linkRoleDirectionSelect.addOption('BOTH', 'Both directions');
+        this.linkRoleDirectionSelect.addOption('DIRECT', 'Direct only');
+        this.linkRoleDirectionSelect.addOption('REVERSE', 'Reverse only');
+    }
+}
+
 const Orientation = {
     orientationSelect: new CustomSelect({
         selectContainer: ctx.getElementById("orientation-select")
@@ -189,6 +201,7 @@ function saveStylePackage() {
             'specificChapters': ctx.getCheckboxValueById('specific-chapters') ? ctx.getValueById('chapters') : null,
             'language': ctx.getCheckboxValueById('localization') ? Languages.languageSelect.getSelectedValue() : null,
             'linkedWorkitemRoles': ctx.getCheckboxValueById('selected-roles') ? LinkRoles.rolesSelect.getSelectedValue() : null,
+            'linkRoleDirection': ctx.getCheckboxValueById('selected-roles') ? LinkRoleDirection.linkRoleDirectionSelect.getSelectedValue() : null,
             'removalSelector': ctx.getValueById('removal-selector-input'),
         }),
         onOk: () => {
@@ -264,6 +277,7 @@ function setStylePackage(content) {
     ctx.setCheckboxValueById('selected-roles', rolesProvided);
     ctx.getElementById('selected-roles').dispatchEvent(new Event('change'));
     LinkRoles.rolesSelect.selectMultipleValues(stylePackage.linkedWorkitemRoles);
+    LinkRoleDirection.linkRoleDirectionSelect.selectValue(stylePackage.linkRoleDirection || 'BOTH');
 
     if (stylePackage.bundleTimestamp !== ctx.getValueById('bundle-timestamp')) {
         ctx.setNewerVersionNotificationVisible(true);
@@ -275,6 +289,7 @@ function newConfigurationCreated() {
 }
 
 RenderComments.init();
+LinkRoleDirection.init();
 Orientation.init();
 PaperSize.init();
 Languages.init();

--- a/src/main/resources/webapp/docx-exporter-admin/pages/style-packages.jsp
+++ b/src/main/resources/webapp/docx-exporter-admin/pages/style-packages.jsp
@@ -229,12 +229,13 @@
                     </label>
                     <input id='chapters' placeholder='eg. 1,2,4 etc.' type='text' style="visibility: hidden; margin-left: 10px; width: 117px"/>
                 </div>
-                <div class='checkbox input-group'>
+                <div class='checkbox input-group' style="display: flex; flex-direction: column; align-items: flex-start; row-gap: 4px;">
                     <label for='selected-roles' style="margin-top: 5px">
-                        <input id="selected-roles" onchange='document.getElementById("roles-select").style.display = this.checked ? "inline-block" : "none"' type='checkbox'/>
+                        <input id="selected-roles" onchange='document.getElementById("roles-select").style.display = this.checked ? "inline-block" : "none"; document.getElementById("link-role-direction-select").style.display = this.checked ? "inline-block" : "none"' type='checkbox'/>
                         Specific Workitem roles
                     </label>
-                    <div id="roles-select" style="display: none; margin-left: 10px; width: 152px"></div>
+                    <div id="roles-select" style="display: none; margin-left: 24px; width: 152px"></div>
+                    <div id="link-role-direction-select" style="display: none; margin-left: 24px; width: 152px"></div>
                 </div>
             </div>
             <div class="flex-column">

--- a/src/main/resources/webapp/docx-exporter/html/popupForm.html
+++ b/src/main/resources/webapp/docx-exporter/html/popupForm.html
@@ -135,12 +135,17 @@
                         <option value='it'>Italiano</option>
                     </select>
                 </div>
-                <div class='property-wrapper'>
-                    <label for='popup-docx-selected-roles' style="align-self: flex-start;">
-                        <input id='popup-docx-selected-roles' onchange='document.getElementById("popup-docx-roles-selector").style.display = this.checked ? "inline-block" : "none"' type='checkbox'/>
+                <div class='property-wrapper' style="flex-direction: column; align-items: flex-start; row-gap: 4px;">
+                    <label for='popup-docx-selected-roles'>
+                        <input id='popup-docx-selected-roles' onchange='document.getElementById("popup-docx-roles-selector").style.display = this.checked ? "inline-block" : "none"; document.getElementById("popup-docx-link-role-direction").style.display = this.checked ? "inline-block" : "none"' type='checkbox'/>
                         Specific Workitem roles
                     </label>
-                    <select id='popup-docx-roles-selector' multiple style="width: 142px"></select>
+                    <select id='popup-docx-roles-selector' multiple style="width: 142px; margin-left: 24px"></select>
+                    <select id='popup-docx-link-role-direction' style="width: 142px; display: none; margin-left: 24px">
+                        <option value='BOTH'>Both directions</option>
+                        <option value='DIRECT'>Direct only</option>
+                        <option value='REVERSE'>Reverse only</option>
+                    </select>
                 </div>
             </div>
         </div>

--- a/src/main/resources/webapp/docx-exporter/html/sidePanelContent.html
+++ b/src/main/resources/webapp/docx-exporter/html/sidePanelContent.html
@@ -117,13 +117,18 @@
         <div class='docx-roles-fields'>
             <div class='property-wrapper'>
                 <label for='docx-selected-roles'>
-                    <input id='docx-selected-roles' onchange='document.querySelector("#docx-exporter-panel #docx-roles-wrapper").style.display = this.checked ? "block" : "none"' type='checkbox'/>
+                    <input id='docx-selected-roles' onchange='document.querySelector("#docx-exporter-panel #docx-roles-wrapper").style.display = this.checked ? "flex" : "none"' type='checkbox'/>
                     Specific Workitem roles
                 </label>
             </div>
-            <div class='property-wrapper' id='docx-roles-wrapper' style='display: none'>
-                <select id='docx-roles-selector' multiple>
+            <div class='property-wrapper' id='docx-roles-wrapper' style='display: none; flex-direction: column; align-items: flex-start; row-gap: 4px; padding-left: 24px'>
+                <select id='docx-roles-selector' multiple style='width: 142px'>
                     {ROLES_OPTIONS}
+                </select>
+                <select id='docx-link-role-direction' style='width: 142px'>
+                    <option value='BOTH'>Both directions</option>
+                    <option value='DIRECT'>Direct only</option>
+                    <option value='REVERSE'>Reverse only</option>
                 </select>
             </div>
         </div>

--- a/src/main/resources/webapp/docx-exporter/js/modules/ExportPanel.js
+++ b/src/main/resources/webapp/docx-exporter/js/modules/ExportPanel.js
@@ -92,7 +92,8 @@ export default class ExportPanel {
                 });
             }
         }
-        this.ctx.displayIf("docx-roles-wrapper", rolesProvided);
+        this.ctx.displayIf("docx-roles-wrapper", rolesProvided, "flex");
+        this.ctx.setValue("docx-link-role-direction", stylePackage.linkRoleDirection || ExportParams.LinkRoleDirection.BOTH);
 
         this.ctx.displayIf("docx-style-package-content", stylePackage.exposeSettings);
     }
@@ -113,15 +114,17 @@ export default class ExportPanel {
         }
 
         const selectedRoles = [];
+        let selectedLinkRoleDirection = null;
         if (this.ctx.getElementById("docx-selected-roles").checked) {
             const selectedOptions = Array.from(this.ctx.getElementById("docx-roles-selector").options).filter(opt => opt.selected);
             selectedRoles.push(...selectedOptions.map(opt => opt.value));
+            selectedLinkRoleDirection = this.ctx.getElementById("docx-link-role-direction").value;
         }
 
-        return this.buildRequestJson(projectId, locationPath, baselineRevision, revision, selectedChapters, selectedRoles, fileName, targetFormat);
+        return this.buildRequestJson(projectId, locationPath, baselineRevision, revision, selectedChapters, selectedRoles, selectedLinkRoleDirection, fileName, targetFormat);
     }
 
-    buildRequestJson(projectId, locationPath, baselineRevision, revision, selectedChapters, selectedRoles, fileName) {
+    buildRequestJson(projectId, locationPath, baselineRevision, revision, selectedChapters, selectedRoles, selectedLinkRoleDirection, fileName) {
         const urlSearchParams = new URL(window.location.href.replace('#', '/')).searchParams;
         return new ExportParams.Builder()
             .setProjectId(projectId)
@@ -141,6 +144,7 @@ export default class ExportPanel {
             .setChapters(selectedChapters)
             .setLanguage(this.ctx.getElementById('docx-localization').checked ? this.ctx.getElementById("docx-language").value : null)
             .setLinkedWorkitemRoles(selectedRoles)
+            .setLinkRoleDirection(selectedLinkRoleDirection)
             .setFileName(fileName)
             .setUrlQueryParameters(Object.fromEntries([...urlSearchParams]))
             .build()

--- a/src/main/resources/webapp/docx-exporter/js/modules/ExportParams.js
+++ b/src/main/resources/webapp/docx-exporter/js/modules/ExportParams.js
@@ -18,6 +18,12 @@ export default class ExportParams {
         LEDGER: 'LEDGER',
     };
 
+    static LinkRoleDirection = {
+        BOTH: 'BOTH',
+        DIRECT: 'DIRECT',
+        REVERSE: 'REVERSE',
+    };
+
     constructor(builder) {
         this.projectId = builder.projectId;
         this.locationPath = builder.locationPath;
@@ -36,6 +42,7 @@ export default class ExportParams {
         this.chapters = builder.chapters;
         this.language = builder.language;
         this.linkedWorkitemRoles = builder.linkedWorkitemRoles;
+        this.linkRoleDirection = builder.linkRoleDirection;
         this.fileName = builder.fileName;
         this.urlQueryParameters = builder.urlQueryParameters;
         this.internalContent = builder.internalContent;
@@ -74,6 +81,7 @@ export default class ExportParams {
                 this.chapters = undefined;
                 this.language = undefined;
                 this.linkedWorkitemRoles = undefined;
+                this.linkRoleDirection = undefined;
                 this.fileName = undefined;
                 this.urlQueryParameters = undefined;
                 this.internalContent = undefined;
@@ -162,6 +170,11 @@ export default class ExportParams {
 
             setLinkedWorkitemRoles(linkedWorkitemRoles) {
                 this.linkedWorkitemRoles = linkedWorkitemRoles;
+                return this;
+            }
+
+            setLinkRoleDirection(linkRoleDirection) {
+                this.linkRoleDirection = linkRoleDirection;
                 return this;
             }
 

--- a/src/main/resources/webapp/docx-exporter/js/modules/ExportPopup.js
+++ b/src/main/resources/webapp/docx-exporter/js/modules/ExportPopup.js
@@ -276,6 +276,9 @@ export default class ExportPopup {
         }
         this.ctx.displayIf("popup-docx-roles-selector", rolesProvided, "inline-block");
 
+        this.ctx.setValue("popup-docx-link-role-direction", stylePackage.linkRoleDirection || ExportParams.LinkRoleDirection.BOTH);
+        this.ctx.displayIf("popup-docx-link-role-direction", rolesProvided, "inline-block");
+
         this.ctx.displayIf("popup-docx-style-package-content", stylePackage.exposeSettings);
     }
 
@@ -329,15 +332,17 @@ export default class ExportPopup {
         }
 
         const selectedRoles = [];
+        let selectedLinkRoleDirection = null;
         if (this.ctx.getElementById("popup-docx-selected-roles").checked) {
             const selectedOptions = Array.from(this.ctx.getElementById("popup-docx-roles-selector").options).filter(opt => opt.selected);
             selectedRoles.push(...selectedOptions.map(opt => opt.value));
+            selectedLinkRoleDirection = this.ctx.getElementById("popup-docx-link-role-direction").value;
         }
 
-        return this.buildExportParams(selectedChapters, selectedRoles, fileName);
+        return this.buildExportParams(selectedChapters, selectedRoles, selectedLinkRoleDirection, fileName);
     }
 
-    buildExportParams(selectedChapters, selectedRoles, fileName) {
+    buildExportParams(selectedChapters, selectedRoles, selectedLinkRoleDirection, fileName) {
         return new ExportParams.Builder()
             .setProjectId(this.ctx.getProjectId())
             .setLocationPath(this.ctx.getLocationPath())
@@ -356,6 +361,7 @@ export default class ExportPopup {
             .setChapters(selectedChapters)
             .setLanguage(this.ctx.getElementById('popup-docx-localization').checked ? this.ctx.getElementById("popup-docx-language").value : null)
             .setLinkedWorkitemRoles(selectedRoles)
+            .setLinkRoleDirection(selectedLinkRoleDirection)
             .setFileName(fileName)
             .setUrlQueryParameters(this.ctx.getUrlQueryParameters())
             .build();

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/DocxExporterFormExtensionTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/DocxExporterFormExtensionTest.java
@@ -72,11 +72,12 @@ class DocxExporterFormExtensionTest {
 
         String result = extension.adjustLinkRoles(form, Collections.emptyList(), StylePackageModel.builder().build());
 
-        assertThat(result).contains("class='docx-roles-fields' style='display: none;'");
-        assertThat(result).contains("{ROLES_OPTIONS}"); // Placeholder untouched when hidden
-        assertThat(result).doesNotContain("<option value='BOTH' selected");
-        assertThat(result).doesNotContain("<option value='DIRECT' selected");
-        assertThat(result).doesNotContain("<option value='REVERSE' selected");
+        assertThat(result)
+                .contains("class='docx-roles-fields' style='display: none;'")
+                .contains("{ROLES_OPTIONS}") // Placeholder untouched when hidden
+                .doesNotContain("<option value='BOTH' selected")
+                .doesNotContain("<option value='DIRECT' selected")
+                .doesNotContain("<option value='REVERSE' selected");
     }
 
     @Test
@@ -86,11 +87,12 @@ class DocxExporterFormExtensionTest {
 
         String result = extension.adjustLinkRoles(form, List.of("relates to", "blocks"), StylePackageModel.builder().build());
 
-        assertThat(result).doesNotContain("{ROLES_OPTIONS}");
-        assertThat(result).contains("<option value='relates to' >relates to</option>");
-        assertThat(result).contains("<option value='blocks' >blocks</option>");
-        assertThat(result).doesNotContain("<input id='docx-selected-roles' checked");
-        assertThat(result).contains("id='docx-roles-wrapper' style='display: none;");
+        assertThat(result)
+                .doesNotContain("{ROLES_OPTIONS}")
+                .contains("<option value='relates to' >relates to</option>")
+                .contains("<option value='blocks' >blocks</option>")
+                .doesNotContain("<input id='docx-selected-roles' checked")
+                .contains("id='docx-roles-wrapper' style='display: none;");
     }
 
     @Test
@@ -100,9 +102,10 @@ class DocxExporterFormExtensionTest {
 
         String result = extension.adjustLinkRoles(form, List.of("relates to"), StylePackageModel.builder().build());
 
-        assertThat(result).contains("<option value='BOTH' selected");
-        assertThat(result).contains("<option value='DIRECT'>");
-        assertThat(result).contains("<option value='REVERSE'>");
+        assertThat(result)
+                .contains("<option value='BOTH' selected")
+                .contains("<option value='DIRECT'>")
+                .contains("<option value='REVERSE'>");
     }
 
     @Test
@@ -115,9 +118,10 @@ class DocxExporterFormExtensionTest {
 
         String result = extension.adjustLinkRoles(form, List.of("relates to"), stylePackage);
 
-        assertThat(result).contains("<option value='DIRECT' selected");
-        assertThat(result).contains("<option value='BOTH'>");
-        assertThat(result).contains("<option value='REVERSE'>");
+        assertThat(result)
+                .contains("<option value='DIRECT' selected")
+                .contains("<option value='BOTH'>")
+                .contains("<option value='REVERSE'>");
     }
 
     @Test
@@ -130,9 +134,10 @@ class DocxExporterFormExtensionTest {
 
         String result = extension.adjustLinkRoles(form, List.of("relates to"), stylePackage);
 
-        assertThat(result).contains("<option value='REVERSE' selected");
-        assertThat(result).contains("<option value='BOTH'>");
-        assertThat(result).contains("<option value='DIRECT'>");
+        assertThat(result)
+                .contains("<option value='REVERSE' selected")
+                .contains("<option value='BOTH'>")
+                .contains("<option value='DIRECT'>");
     }
 
     @Test
@@ -146,11 +151,12 @@ class DocxExporterFormExtensionTest {
 
         String result = extension.adjustLinkRoles(form, List.of("relates to", "blocks"), stylePackage);
 
-        assertThat(result).contains("<input id='docx-selected-roles' checked");
-        assertThat(result).contains("id='docx-roles-wrapper' style='display: flex;");
-        assertThat(result).contains("<option value='blocks' selected>blocks</option>");
-        assertThat(result).contains("<option value='relates to' >relates to</option>");
-        assertThat(result).contains("<option value='DIRECT' selected");
+        assertThat(result)
+                .contains("<input id='docx-selected-roles' checked")
+                .contains("id='docx-roles-wrapper' style='display: flex;")
+                .contains("<option value='blocks' selected>blocks</option>")
+                .contains("<option value='relates to' >relates to</option>")
+                .contains("<option value='DIRECT' selected");
     }
 
     private String buildRolesFormFragment() {

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/DocxExporterFormExtensionTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/DocxExporterFormExtensionTest.java
@@ -2,6 +2,7 @@ package ch.sbb.polarion.extension.docx_exporter;
 
 import ch.sbb.polarion.extension.docx_exporter.configuration.DocxExporterExtensionConfigurationExtension;
 import ch.sbb.polarion.extension.docx_exporter.rest.model.conversion.CommentsRenderType;
+import ch.sbb.polarion.extension.docx_exporter.rest.model.conversion.LinkRoleDirection;
 import ch.sbb.polarion.extension.docx_exporter.rest.model.settings.stylepackage.StylePackageModel;
 import ch.sbb.polarion.extension.docx_exporter.util.EnumValuesProvider;
 import ch.sbb.polarion.extension.generic.settings.SettingName;
@@ -17,8 +18,10 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 @ExtendWith({MockitoExtension.class, PlatformContextMockExtension.class, DocxExporterExtensionConfigurationExtension.class})
@@ -60,6 +63,108 @@ class DocxExporterFormExtensionTest {
             extension.renderForm(context, module);
             verify(builder, times(1)).html(argThat(arg -> expectedEntries.stream().allMatch(arg::contains)));
         }
+    }
+
+    @Test
+    void adjustLinkRolesShouldHideFieldsWhenNoRolesAvailable() {
+        DocxExporterFormExtension extension = new DocxExporterFormExtension();
+        String form = buildRolesFormFragment();
+
+        String result = extension.adjustLinkRoles(form, Collections.emptyList(), StylePackageModel.builder().build());
+
+        assertThat(result).contains("class='docx-roles-fields' style='display: none;'");
+        assertThat(result).contains("{ROLES_OPTIONS}"); // Placeholder untouched when hidden
+        assertThat(result).doesNotContain("<option value='BOTH' selected");
+        assertThat(result).doesNotContain("<option value='DIRECT' selected");
+        assertThat(result).doesNotContain("<option value='REVERSE' selected");
+    }
+
+    @Test
+    void adjustLinkRolesShouldRenderAllOptionsUnselectedWhenStylePackageHasNoSelection() {
+        DocxExporterFormExtension extension = new DocxExporterFormExtension();
+        String form = buildRolesFormFragment();
+
+        String result = extension.adjustLinkRoles(form, List.of("relates to", "blocks"), StylePackageModel.builder().build());
+
+        assertThat(result).doesNotContain("{ROLES_OPTIONS}");
+        assertThat(result).contains("<option value='relates to' >relates to</option>");
+        assertThat(result).contains("<option value='blocks' >blocks</option>");
+        assertThat(result).doesNotContain("<input id='docx-selected-roles' checked");
+        assertThat(result).contains("id='docx-roles-wrapper' style='display: none;");
+    }
+
+    @Test
+    void adjustLinkRolesShouldDefaultDirectionToBothWhenNull() {
+        DocxExporterFormExtension extension = new DocxExporterFormExtension();
+        String form = buildRolesFormFragment();
+
+        String result = extension.adjustLinkRoles(form, List.of("relates to"), StylePackageModel.builder().build());
+
+        assertThat(result).contains("<option value='BOTH' selected");
+        assertThat(result).contains("<option value='DIRECT'>");
+        assertThat(result).contains("<option value='REVERSE'>");
+    }
+
+    @Test
+    void adjustLinkRolesShouldPreselectDirectDirection() {
+        DocxExporterFormExtension extension = new DocxExporterFormExtension();
+        String form = buildRolesFormFragment();
+        StylePackageModel stylePackage = StylePackageModel.builder()
+                .linkRoleDirection(LinkRoleDirection.DIRECT.toString())
+                .build();
+
+        String result = extension.adjustLinkRoles(form, List.of("relates to"), stylePackage);
+
+        assertThat(result).contains("<option value='DIRECT' selected");
+        assertThat(result).contains("<option value='BOTH'>");
+        assertThat(result).contains("<option value='REVERSE'>");
+    }
+
+    @Test
+    void adjustLinkRolesShouldPreselectReverseDirection() {
+        DocxExporterFormExtension extension = new DocxExporterFormExtension();
+        String form = buildRolesFormFragment();
+        StylePackageModel stylePackage = StylePackageModel.builder()
+                .linkRoleDirection(LinkRoleDirection.REVERSE.toString())
+                .build();
+
+        String result = extension.adjustLinkRoles(form, List.of("relates to"), stylePackage);
+
+        assertThat(result).contains("<option value='REVERSE' selected");
+        assertThat(result).contains("<option value='BOTH'>");
+        assertThat(result).contains("<option value='DIRECT'>");
+    }
+
+    @Test
+    void adjustLinkRolesShouldCheckCheckboxAndRevealWrapperWhenRolesSelected() {
+        DocxExporterFormExtension extension = new DocxExporterFormExtension();
+        String form = buildRolesFormFragment();
+        StylePackageModel stylePackage = StylePackageModel.builder()
+                .linkedWorkitemRoles(List.of("blocks"))
+                .linkRoleDirection(LinkRoleDirection.DIRECT.toString())
+                .build();
+
+        String result = extension.adjustLinkRoles(form, List.of("relates to", "blocks"), stylePackage);
+
+        assertThat(result).contains("<input id='docx-selected-roles' checked");
+        assertThat(result).contains("id='docx-roles-wrapper' style='display: flex;");
+        assertThat(result).contains("<option value='blocks' selected>blocks</option>");
+        assertThat(result).contains("<option value='relates to' >relates to</option>");
+        assertThat(result).contains("<option value='DIRECT' selected");
+    }
+
+    private String buildRolesFormFragment() {
+        return "<div class='docx-roles-fields'>"
+                + "<input id='docx-selected-roles' type='checkbox'/>"
+                + "<div id='docx-roles-wrapper' style='display: none; flex-direction: column'>"
+                + "<select id='docx-roles-selector' multiple>{ROLES_OPTIONS}</select>"
+                + "<select id='docx-link-role-direction'>"
+                + "<option value='BOTH'>Both directions</option>"
+                + "<option value='DIRECT'>Direct only</option>"
+                + "<option value='REVERSE'>Reverse only</option>"
+                + "</select>"
+                + "</div>"
+                + "</div>";
     }
 
 }

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/converter/DocxConverterTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/converter/DocxConverterTest.java
@@ -4,6 +4,7 @@ import ch.sbb.polarion.extension.docx_exporter.configuration.DocxExporterExtensi
 import ch.sbb.polarion.extension.docx_exporter.pandoc.service.PandocServiceConnector;
 import ch.sbb.polarion.extension.docx_exporter.pandoc.service.model.PandocParams;
 import ch.sbb.polarion.extension.docx_exporter.rest.model.conversion.ExportParams;
+import ch.sbb.polarion.extension.docx_exporter.rest.model.conversion.LinkRoleDirection;
 import ch.sbb.polarion.extension.docx_exporter.rest.model.documents.DocumentData;
 import ch.sbb.polarion.extension.docx_exporter.rest.model.documents.id.LiveDocId;
 import ch.sbb.polarion.extension.docx_exporter.rest.model.settings.templates.TemplatesModel;
@@ -110,10 +111,56 @@ class DocxConverterTest {
     @Test
     @SuppressWarnings("unchecked")
     void shouldPostProcessDocumentContent() {
-        // Arrange
+        ExportParams exportParams = ExportParams.builder()
+                .linkedWorkitemRoles(List.of("role1", "role2"))
+                .linkRoleDirection(LinkRoleDirection.BOTH)
+                .build();
+
+        List<String> captured = runPostProcessAndCaptureRoles(exportParams);
+
+        assertThat(captured).containsExactly("role1", "testRole1OppositeName", "role2", "testRole2OppositeName");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldPostProcessDocumentContentDirectOnly() {
+        ExportParams exportParams = ExportParams.builder()
+                .linkedWorkitemRoles(List.of("role1", "role2"))
+                .linkRoleDirection(LinkRoleDirection.DIRECT)
+                .build();
+
+        List<String> captured = runPostProcessAndCaptureRoles(exportParams);
+
+        assertThat(captured).containsExactly("role1", "role2");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldPostProcessDocumentContentReverseOnly() {
+        ExportParams exportParams = ExportParams.builder()
+                .linkedWorkitemRoles(List.of("role1", "role2"))
+                .linkRoleDirection(LinkRoleDirection.REVERSE)
+                .build();
+
+        List<String> captured = runPostProcessAndCaptureRoles(exportParams);
+
+        assertThat(captured).containsExactly("testRole1OppositeName", "testRole2OppositeName");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldPostProcessDocumentContentNullDirectionDefaultsToBoth() {
         ExportParams exportParams = ExportParams.builder()
                 .linkedWorkitemRoles(List.of("role1", "role2"))
                 .build();
+
+        List<String> captured = runPostProcessAndCaptureRoles(exportParams);
+
+        assertThat(captured).containsExactly("role1", "testRole1OppositeName", "role2", "testRole2OppositeName");
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> runPostProcessAndCaptureRoles(ExportParams exportParams) {
         ITrackerProject project = mock(ITrackerProject.class);
         IEnumeration<ILinkRoleOpt> roleEnum = mock(IEnumeration.class);
         Properties props1 = new Properties();
@@ -130,15 +177,13 @@ class DocxConverterTest {
         when(project.getWorkItemLinkRoleEnum()).thenReturn(roleEnum);
         when(htmlProcessor.processHtmlForExport(anyString(), eq(exportParams), any(List.class), any())).thenReturn("result string");
 
-        // Act
         DocxConverter docxConverter = new DocxConverter(null, null, htmlProcessor, null);
         String resultContent = docxConverter.postProcessDocumentContent(exportParams, project, "test content");
 
-        // Assert
         assertThat(resultContent).isEqualTo("result string");
         ArgumentCaptor<List<String>> rolesCaptor = ArgumentCaptor.forClass(List.class);
         verify(htmlProcessor).processHtmlForExport(eq("test content"), eq(exportParams), rolesCaptor.capture(), any());
-        assertThat(rolesCaptor.getValue()).containsExactly("role1", "testRole1OppositeName", "role2", "testRole2OppositeName");
+        return rolesCaptor.getValue();
     }
 
 }

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/settings/StylePackageSettingsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/settings/StylePackageSettingsTest.java
@@ -7,6 +7,7 @@ import ch.sbb.polarion.extension.generic.settings.GenericNamedSettings;
 import ch.sbb.polarion.extension.generic.settings.SettingId;
 import ch.sbb.polarion.extension.generic.settings.SettingsService;
 import ch.sbb.polarion.extension.generic.util.ScopeUtils;
+import ch.sbb.polarion.extension.docx_exporter.rest.model.conversion.LinkRoleDirection;
 import ch.sbb.polarion.extension.docx_exporter.rest.model.settings.stylepackage.StylePackageModel;
 import com.polarion.subterra.base.location.ILocation;
 import org.junit.jupiter.api.Test;
@@ -86,6 +87,43 @@ class StylePackageSettingsTest {
             assertEquals("custom", loadedModel.getBundleTimestamp());
 
             assertNull(loadedModel.getRenderComments());
+            assertNull(loadedModel.getLinkRoleDirection());
+        }
+    }
+
+    @Test
+    void testLinkRoleDirectionRoundTrip() {
+        try (MockedStatic<ScopeUtils> mockScopeUtils = mockStatic(ScopeUtils.class)) {
+            SettingsService mockedSettingsService = mock(SettingsService.class);
+            mockScopeUtils.when(() -> ScopeUtils.getFileContent(any())).thenCallRealMethod();
+
+            GenericNamedSettings<StylePackageModel> stylePackageSettings = new StylePackageSettings(mockedSettingsService);
+
+            String projectName = "test_project";
+
+            ILocation mockDefaultLocation = mock(ILocation.class);
+            when(mockDefaultLocation.append(anyString())).thenReturn(mockDefaultLocation);
+            mockScopeUtils.when(() -> ScopeUtils.getContextLocation("")).thenReturn(mockDefaultLocation);
+
+            ILocation mockProjectLocation = mock(ILocation.class);
+            when(mockProjectLocation.append(anyString())).thenReturn(mockProjectLocation);
+            mockScopeUtils.when(() -> ScopeUtils.getContextLocationByProject(projectName)).thenReturn(mockProjectLocation);
+            mockScopeUtils.when(() -> ScopeUtils.getScopeFromProject(projectName)).thenCallRealMethod();
+            mockScopeUtils.when(() -> ScopeUtils.getContextLocation("project/test_project/")).thenReturn(mockProjectLocation);
+
+            StylePackageModel savedModel = StylePackageModel.builder()
+                    .linkedWorkitemRoles(List.of("has parent"))
+                    .linkRoleDirection(LinkRoleDirection.DIRECT.toString())
+                    .build();
+            savedModel.setBundleTimestamp("custom");
+            when(mockedSettingsService.read(eq(mockProjectLocation), any())).thenReturn(savedModel.serialize());
+
+            when(mockedSettingsService.getLastRevision(mockProjectLocation)).thenReturn("345");
+            when(mockedSettingsService.getPersistedSettingFileNames(mockProjectLocation)).thenReturn(List.of("Any setting name"));
+
+            StylePackageModel loadedModel = stylePackageSettings.load(projectName, SettingId.fromName("Any setting name"));
+            assertEquals(LinkRoleDirection.DIRECT.toString(), loadedModel.getLinkRoleDirection());
+            assertEquals(List.of("has parent"), loadedModel.getLinkedWorkitemRoles());
         }
     }
 

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/EnumValuesProviderTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/EnumValuesProviderTest.java
@@ -1,0 +1,98 @@
+package ch.sbb.polarion.extension.docx_exporter.util;
+
+import ch.sbb.polarion.extension.docx_exporter.rest.model.conversion.LinkRoleDirection;
+import com.polarion.alm.tracker.internal.model.LinkRoleOpt;
+import com.polarion.alm.tracker.internal.model.TypeOpt;
+import com.polarion.alm.tracker.model.ILinkRoleOpt;
+import com.polarion.alm.tracker.model.ITrackerProject;
+import com.polarion.alm.tracker.model.ITypeOpt;
+import com.polarion.platform.persistence.IEnumeration;
+import com.polarion.platform.persistence.spi.EnumOption;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EnumValuesProviderTest {
+
+    @Test
+    void shouldReturnEmptyListWhenSelectedRoleNamesIsNull() {
+        ITrackerProject project = mock(ITrackerProject.class);
+
+        List<String> result = EnumValuesProvider.getLinkRoleNames(project, null, LinkRoleDirection.BOTH);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenSelectedRoleNamesIsEmpty() {
+        ITrackerProject project = mock(ITrackerProject.class);
+
+        List<String> result = EnumValuesProvider.getLinkRoleNames(project, Collections.emptyList(), LinkRoleDirection.BOTH);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldReturnBothNamesWhenDirectionIsBoth() {
+        ITrackerProject project = buildProjectWithTwoRoles();
+
+        List<String> result = EnumValuesProvider.getLinkRoleNames(project, List.of("role1", "role2"), LinkRoleDirection.BOTH);
+
+        assertThat(result).containsExactly("role1", "testRole1OppositeName", "role2", "testRole2OppositeName");
+    }
+
+    @Test
+    void shouldReturnOnlyDirectNamesWhenDirectionIsDirect() {
+        ITrackerProject project = buildProjectWithTwoRoles();
+
+        List<String> result = EnumValuesProvider.getLinkRoleNames(project, List.of("role1", "role2"), LinkRoleDirection.DIRECT);
+
+        assertThat(result).containsExactly("role1", "role2");
+    }
+
+    @Test
+    void shouldReturnOnlyReverseNamesWhenDirectionIsReverse() {
+        ITrackerProject project = buildProjectWithTwoRoles();
+
+        List<String> result = EnumValuesProvider.getLinkRoleNames(project, List.of("role1", "role2"), LinkRoleDirection.REVERSE);
+
+        assertThat(result).containsExactly("testRole1OppositeName", "testRole2OppositeName");
+    }
+
+    @Test
+    void shouldDefaultToBothWhenDirectionIsNull() {
+        ITrackerProject project = buildProjectWithTwoRoles();
+
+        List<String> result = EnumValuesProvider.getLinkRoleNames(project, List.of("role1", "role2"), null);
+
+        assertThat(result).containsExactly("role1", "testRole1OppositeName", "role2", "testRole2OppositeName");
+    }
+
+    @SuppressWarnings("unchecked")
+    private ITrackerProject buildProjectWithTwoRoles() {
+        ITrackerProject project = mock(ITrackerProject.class);
+        IEnumeration<ILinkRoleOpt> roleEnum = mock(IEnumeration.class);
+        Properties props1 = new Properties();
+        props1.put("oppositeName", "testRole1OppositeName");
+        ILinkRoleOpt option1 = new LinkRoleOpt(new EnumOption("roleLink", "role1", "role1", 1, false, props1));
+        Properties props2 = new Properties();
+        props2.put("oppositeName", "testRole2OppositeName");
+        ILinkRoleOpt option2 = new LinkRoleOpt(new EnumOption("roleLink", "role2", "role2", 1, false, props2));
+        when(roleEnum.getAvailableOptions("wiType")).thenReturn(List.of(option1, option2));
+        IEnumeration<ITypeOpt> typeEnum = mock(IEnumeration.class);
+        TypeOpt typeOption = new TypeOpt(new EnumOption("wiType", "wiType", "WIType", 1, false));
+        when(typeEnum.getAllOptions()).thenReturn(List.of(typeOption));
+        when(project.getWorkItemTypeEnum()).thenReturn(typeEnum);
+        when(project.getWorkItemLinkRoleEnum()).thenReturn(roleEnum);
+        return project;
+    }
+}


### PR DESCRIPTION
Fixes: #210

### Proposed changes

When user uses link role filter during export, previously both directions were applied ("has parent" / "is parent of"). This change introduces possibility to choose if still both directions should be applied, or only direct one, or only reverse one.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
