### PR TITLE
feat: ability to export unreferenced comments

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1595,6 +1595,10 @@
             "description": "Target file name of exported document",
             "type": "string"
           },
+          "includeUnreferencedComments": {
+            "description": "Include unreferenced comments",
+            "type": "boolean"
+          },
           "internalContent": {
             "description": "Internal content",
             "type": "string"

--- a/package-lock.json
+++ b/package-lock.json
@@ -167,6 +167,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -215,6 +216,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/DocxExporterFormExtension.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/DocxExporterFormExtension.java
@@ -181,11 +181,16 @@ public class DocxExporterFormExtension implements IFormExtension {
         }
     }
 
-    private String adjustRenderComments(String form, StylePackageModel stylePackage) {
+    @VisibleForTesting
+    String adjustRenderComments(String form, StylePackageModel stylePackage) {
         if (stylePackage.getRenderComments() != null) {
             form = form.replace("<input id='render-comments'", "<input id='render-comments' checked");
             form = form.replace("id='render-comments-selector' style='display: none'", "id='render-comments-selector'");
             form = form.replace(String.format(OPTION_VALUE, stylePackage.getRenderComments()), String.format(OPTION_SELECTED, stylePackage.getRenderComments()));
+            form = form.replace("id='render-comments-options' style='display: none", "id='render-comments-options' style='display: flex");
+            if (stylePackage.isIncludeUnreferencedComments()) {
+                form = form.replace("<input id='include-unreferenced-comments'", "<input id='include-unreferenced-comments' checked");
+            }
         }
         return form;
     }

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/rest/model/conversion/ExportParams.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/rest/model/conversion/ExportParams.java
@@ -48,6 +48,9 @@ public class ExportParams {
     @Schema(description = "Which comments should be rendered in the exported document")
     private CommentsRenderType renderComments;
 
+    @Schema(description = "Include unreferenced comments")
+    private boolean includeUnreferencedComments;
+
     @Schema(description = "Empty chapters should be removed from the document")
     private boolean cutEmptyChapters;
 

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/rest/model/documents/adapters/LiveDocAdapter.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/rest/model/documents/adapters/LiveDocAdapter.java
@@ -2,6 +2,7 @@ package ch.sbb.polarion.extension.docx_exporter.rest.model.documents.adapters;
 
 import ch.sbb.polarion.extension.docx_exporter.rest.model.conversion.CommentsRenderType;
 import ch.sbb.polarion.extension.docx_exporter.rest.model.conversion.ExportParams;
+import ch.sbb.polarion.extension.docx_exporter.model.LiveDocComment;
 import ch.sbb.polarion.extension.docx_exporter.rest.model.documents.id.DocumentId;
 import ch.sbb.polarion.extension.docx_exporter.rest.model.documents.id.DocumentProject;
 import ch.sbb.polarion.extension.docx_exporter.rest.model.documents.id.LiveDocId;
@@ -20,7 +21,7 @@ import com.polarion.core.util.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.VisibleForTesting;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -65,17 +66,19 @@ public class LiveDocAdapter extends CommonUniqueObjectAdapter {
             ProxyDocument document = new ProxyDocument(module, (InternalReadOnlyTransaction) transaction);
 
             String internalContent = StringUtils.getEmptyIfNull(exportParams.getInternalContent() != null ? exportParams.getInternalContent() : document.getHomePageContentHtml());
-            Set<String> usedCommentIds = new HashSet<>();
-            internalContent = processLiveDocComments(exportParams, document, internalContent, usedCommentIds);
+            Set<String> renderedCommentIds = new LinkedHashSet<>();
+            LiveDocCommentsProcessor commentsProcessor = new LiveDocCommentsProcessor();
+            Map<String, LiveDocComment> liveDocComments = commentsProcessor.getLiveDocComments(document, exportParams.getRenderComments());
+            internalContent = commentsProcessor.addLiveDocComments(internalContent, liveDocComments, renderedCommentIds);
             if (exportParams.getRenderComments() != null) {
                 // Add inline comments into document content
                 internalContent = new WorkItemCommentsProcessor().addWorkItemComments(document, internalContent, CommentsRenderType.OPEN.equals(exportParams.getRenderComments()));
             }
             ModifiedDocumentRenderer documentRenderer = getDocumentRenderer(exportParams, (InternalReadOnlyTransaction) transaction, document);
             String rendered = documentRenderer.render(internalContent);
-            rendered = processLiveDocComments(exportParams, document, rendered, usedCommentIds);
+            rendered = commentsProcessor.addLiveDocComments(rendered, liveDocComments, renderedCommentIds);
             if (exportParams.isIncludeUnreferencedComments()) {
-                rendered = processUnreferencedComments(exportParams, document, rendered, usedCommentIds);
+                rendered = commentsProcessor.addUnreferencedComments(rendered, liveDocComments, renderedCommentIds);
             }
             return rendered;
         });
@@ -86,14 +89,6 @@ public class LiveDocAdapter extends CommonUniqueObjectAdapter {
         Map<String, String> documentParameters = exportParams.getUrlQueryParameters() == null ? Map.of() : exportParams.getUrlQueryParameters();
         DocumentRendererParameters parameters = new DocumentRendererParameters(documentParameters.get(ExportParams.URL_QUERY_PARAM_QUERY), documentParameters.get(ExportParams.URL_QUERY_PARAM_LANGUAGE));
         return new ModifiedDocumentRenderer(transaction, document, RichTextRenderTarget.PDF_EXPORT, parameters);
-    }
-
-    private String processLiveDocComments(@NotNull ExportParams exportParams, @NotNull ProxyDocument document, @NotNull String content, @NotNull Set<String> usedCommentIds) {
-        return new LiveDocCommentsProcessor().addLiveDocComments(document, content, exportParams.getRenderComments(), usedCommentIds);
-    }
-
-    private String processUnreferencedComments(@NotNull ExportParams exportParams, @NotNull ProxyDocument document, @NotNull String content, @NotNull Set<String> usedCommentIds) {
-        return new LiveDocCommentsProcessor().addUnreferencedComments(document, content, exportParams.getRenderComments(), usedCommentIds);
     }
 
 }

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/rest/model/documents/adapters/LiveDocAdapter.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/rest/model/documents/adapters/LiveDocAdapter.java
@@ -20,7 +20,9 @@ import com.polarion.core.util.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.VisibleForTesting;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 public class LiveDocAdapter extends CommonUniqueObjectAdapter {
     public static final String DOC_REVISION_CUSTOM_FIELD = "docRevision";
@@ -63,14 +65,19 @@ public class LiveDocAdapter extends CommonUniqueObjectAdapter {
             ProxyDocument document = new ProxyDocument(module, (InternalReadOnlyTransaction) transaction);
 
             String internalContent = StringUtils.getEmptyIfNull(exportParams.getInternalContent() != null ? exportParams.getInternalContent() : document.getHomePageContentHtml());
-            internalContent = processLiveDocComments(exportParams, document, internalContent);
+            Set<String> usedCommentIds = new HashSet<>();
+            internalContent = processLiveDocComments(exportParams, document, internalContent, usedCommentIds);
             if (exportParams.getRenderComments() != null) {
                 // Add inline comments into document content
                 internalContent = new WorkItemCommentsProcessor().addWorkItemComments(document, internalContent, CommentsRenderType.OPEN.equals(exportParams.getRenderComments()));
             }
             ModifiedDocumentRenderer documentRenderer = getDocumentRenderer(exportParams, (InternalReadOnlyTransaction) transaction, document);
             String rendered = documentRenderer.render(internalContent);
-            return processLiveDocComments(exportParams, document, rendered);
+            rendered = processLiveDocComments(exportParams, document, rendered, usedCommentIds);
+            if (exportParams.isIncludeUnreferencedComments()) {
+                rendered = processUnreferencedComments(exportParams, document, rendered, usedCommentIds);
+            }
+            return rendered;
         });
     }
 
@@ -81,8 +88,12 @@ public class LiveDocAdapter extends CommonUniqueObjectAdapter {
         return new ModifiedDocumentRenderer(transaction, document, RichTextRenderTarget.PDF_EXPORT, parameters);
     }
 
-    private String processLiveDocComments(@NotNull ExportParams exportParams, @NotNull ProxyDocument document, @NotNull String content) {
-        return new LiveDocCommentsProcessor().addLiveDocComments(document, content, exportParams.getRenderComments());
+    private String processLiveDocComments(@NotNull ExportParams exportParams, @NotNull ProxyDocument document, @NotNull String content, @NotNull Set<String> usedCommentIds) {
+        return new LiveDocCommentsProcessor().addLiveDocComments(document, content, exportParams.getRenderComments(), usedCommentIds);
+    }
+
+    private String processUnreferencedComments(@NotNull ExportParams exportParams, @NotNull ProxyDocument document, @NotNull String content, @NotNull Set<String> usedCommentIds) {
+        return new LiveDocCommentsProcessor().addUnreferencedComments(document, content, exportParams.getRenderComments(), usedCommentIds);
     }
 
 }

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/rest/model/settings/stylepackage/StylePackageModel.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/rest/model/settings/stylepackage/StylePackageModel.java
@@ -36,6 +36,7 @@ public class StylePackageModel extends SettingsModel {
     private static final String WEBHOOKS_ENTRY_NAME = "WEBHOOKS";
     private static final String REMOVAL_SELECTOR_ENTRY_NAME = "REMOVAL SELECTOR";
     private static final String RENDER_COMMENTS_ENTRY_NAME = "RENDER COMMENTS";
+    private static final String INCLUDE_UNREFERENCED_COMMENTS_ENTRY_NAME = "INCLUDE UNREFERENCED COMMENTS";
     private static final String CUT_EMPTY_CHAPTERS_ENTRY_NAME = "CUT EMPTY CHAPTERS";
     private static final String CUT_EMPTY_WORKITEM_ATTRIBUTES_ENTRY_NAME = "CUT EMPTY WORKITEM ATTRIBUTES";
     private static final String CUT_LOCAL_URLS_ENTRY_NAME= "CUT LOCAL URLS";
@@ -58,6 +59,7 @@ public class StylePackageModel extends SettingsModel {
     // Add a new style package settings - text input `Removal selector`. It expects expression like CSS (e.g. `.polarion-Hyperlink .polarion-Icons`) - html elements queried using this expression will be removed from source html.
     private String removalSelector;
     private CommentsRenderType renderComments;
+    private boolean includeUnreferencedComments;
     private boolean cutEmptyChapters;
     private boolean cutEmptyWorkitemAttributes;
     private boolean cutLocalURLs;
@@ -78,6 +80,7 @@ public class StylePackageModel extends SettingsModel {
                 serializeEntry(WEBHOOKS_ENTRY_NAME, webhooks) +
                 serializeEntry(REMOVAL_SELECTOR_ENTRY_NAME, removalSelector) +
                 serializeEntry(RENDER_COMMENTS_ENTRY_NAME, renderComments == null ? null : renderComments.name()) +
+                serializeEntry(INCLUDE_UNREFERENCED_COMMENTS_ENTRY_NAME, includeUnreferencedComments) +
                 serializeEntry(CUT_EMPTY_CHAPTERS_ENTRY_NAME, cutEmptyChapters) +
                 serializeEntry(CUT_EMPTY_WORKITEM_ATTRIBUTES_ENTRY_NAME, cutEmptyWorkitemAttributes) +
                 serializeEntry(CUT_LOCAL_URLS_ENTRY_NAME, cutLocalURLs) +
@@ -101,6 +104,7 @@ public class StylePackageModel extends SettingsModel {
         webhooks = deserializeEntry(WEBHOOKS_ENTRY_NAME, serializedString);
         removalSelector = deserializeEntry(REMOVAL_SELECTOR_ENTRY_NAME, serializedString);
         renderComments = parseRenderComments(deserializeEntry(RENDER_COMMENTS_ENTRY_NAME, serializedString));
+        includeUnreferencedComments = Boolean.parseBoolean(deserializeEntry(INCLUDE_UNREFERENCED_COMMENTS_ENTRY_NAME, serializedString));
         cutEmptyChapters = Boolean.parseBoolean(deserializeEntry(CUT_EMPTY_CHAPTERS_ENTRY_NAME, serializedString));
         cutEmptyWorkitemAttributes = Boolean.parseBoolean(deserializeEntry(CUT_EMPTY_WORKITEM_ATTRIBUTES_ENTRY_NAME, serializedString));
         cutLocalURLs = Boolean.parseBoolean(deserializeEntry(CUT_LOCAL_URLS_ENTRY_NAME, serializedString));

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessor.java
@@ -902,6 +902,7 @@ public class HtmlProcessor {
         html = html.replace("[span class=status-resolved]", "<span class='status-resolved'>");
         html = html.replace("[span class=author]", "<span class='author'>");
         html = html.replace("[span class=text]", "<span class='text'>");
+        html = html.replace("[span class=unreferenced-comments-delimiter]", "<span class='unreferenced-comments-delimiter'>");
         html = html.replace(COMMENT_END, SPAN_END_TAG);
 
         Document parsedHtml = Jsoup.parse(html);

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/LiveDocCommentsProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/LiveDocCommentsProcessor.java
@@ -24,8 +24,10 @@ import org.jetbrains.annotations.Nullable;
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 @SuppressWarnings("java:S1200")
 public class LiveDocCommentsProcessor {
@@ -79,7 +81,7 @@ public class LiveDocCommentsProcessor {
     }
 
     @NotNull
-    public String addLiveDocComments(ProxyDocument document, @NotNull String html, @Nullable CommentsRenderType commentsRenderType) {
+    public String addLiveDocComments(ProxyDocument document, @NotNull String html, @Nullable CommentsRenderType commentsRenderType, @NotNull Set<String> usedCommentIds) {
         //Polarion document keeps comments position in span/img marked with id 'polarion-comment:commentId'.
         //<span id="polarion-comment:1"></span> or <img id="polarion-comment:1" class="polarion-dle-comment-icon"/> (for comments inside workitem description)
         //Note that resolved comments have class 'polarion-dle-comment-resolved-icon' so we have to take care of them too.
@@ -87,8 +89,23 @@ public class LiveDocCommentsProcessor {
         return RegexMatcher.get("(?s)((<img id=\"polarion-comment:(?<imgCommentId>\\d+)\"[^>]*class=\"polarion-dle-comment(?:-resolved)?-icon\"/>)|(<span id=\"polarion-comment:(?<spanCommentId>\\d+)\"></span>))")
                 .replace(html, regexEngine -> {
                     String commentId = Optional.ofNullable(regexEngine.group("imgCommentId")).orElse(regexEngine.group("spanCommentId"));
+                    usedCommentIds.add(commentId);
                     return renderComment(liveDocComments.get(commentId), 0);
                 });
+    }
+
+    @NotNull
+    public String addUnreferencedComments(ProxyDocument document, @NotNull String html, @Nullable CommentsRenderType commentsRenderType, @NotNull Set<String> usedCommentIds) {
+        final Map<String, LiveDocComment> liveDocComments = commentsRenderType == null ? Map.of() : getCommentsFromDocument(document, commentsRenderType.equals(CommentsRenderType.OPEN));
+        List<LiveDocComment> unreferencedComments = liveDocComments.entrySet().stream().filter(entry -> !usedCommentIds.contains(entry.getKey())).map(Map.Entry::getValue).toList();
+        if (!unreferencedComments.isEmpty()) {
+            StringBuilder modifiedContent = new StringBuilder(html);
+            modifiedContent.append("[span class=unreferenced-comments-delimiter][/span]");
+            unreferencedComments.forEach(comment -> modifiedContent.append(renderComment(comment, 0)));
+            return modifiedContent.toString();
+        } else {
+            return html;
+        }
     }
 
     private String renderComment(LiveDocComment liveDocComment, int nestingLevel) {

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/LiveDocCommentsProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/LiveDocCommentsProcessor.java
@@ -32,9 +32,14 @@ import java.util.Set;
 @SuppressWarnings("java:S1200")
 public class LiveDocCommentsProcessor {
 
-    private Map<String, LiveDocComment> getCommentsFromDocument(ProxyDocument document, boolean onlyOpen) {
+    @NotNull
+    public Map<String, LiveDocComment> getLiveDocComments(@NotNull ProxyDocument document, @Nullable CommentsRenderType commentsRenderType) {
+        if (commentsRenderType == null) {
+            return Map.of();
+        }
         final UpdatableDocumentFields fields = document.fields();
         final CommentBasesTreeField<CommentBase> comments = fields.comments();
+        boolean onlyOpen = commentsRenderType == CommentsRenderType.OPEN;
         Map<String, LiveDocComment> liveDocCommentMap = new HashMap<>();
         comments.forEach(commentBase -> {
             LiveDocComment liveDocComment = getCommentFromCommentBase(commentBase);
@@ -81,23 +86,21 @@ public class LiveDocCommentsProcessor {
     }
 
     @NotNull
-    public String addLiveDocComments(ProxyDocument document, @NotNull String html, @Nullable CommentsRenderType commentsRenderType, @NotNull Set<String> usedCommentIds) {
+    public String addLiveDocComments(@NotNull String html, @NotNull Map<String, LiveDocComment> liveDocComments, @NotNull Set<String> renderedCommentIds) {
         //Polarion document keeps comments position in span/img marked with id 'polarion-comment:commentId'.
         //<span id="polarion-comment:1"></span> or <img id="polarion-comment:1" class="polarion-dle-comment-icon"/> (for comments inside workitem description)
         //Note that resolved comments have class 'polarion-dle-comment-resolved-icon' so we have to take care of them too.
-        final Map<String, LiveDocComment> liveDocComments = commentsRenderType == null ? Map.of() : getCommentsFromDocument(document, commentsRenderType.equals(CommentsRenderType.OPEN));
         return RegexMatcher.get("(?s)((<img id=\"polarion-comment:(?<imgCommentId>\\d+)\"[^>]*class=\"polarion-dle-comment(?:-resolved)?-icon\"/>)|(<span id=\"polarion-comment:(?<spanCommentId>\\d+)\"></span>))")
                 .replace(html, regexEngine -> {
                     String commentId = Optional.ofNullable(regexEngine.group("imgCommentId")).orElse(regexEngine.group("spanCommentId"));
-                    usedCommentIds.add(commentId);
+                    renderedCommentIds.add(commentId);
                     return renderComment(liveDocComments.get(commentId), 0);
                 });
     }
 
     @NotNull
-    public String addUnreferencedComments(ProxyDocument document, @NotNull String html, @Nullable CommentsRenderType commentsRenderType, @NotNull Set<String> usedCommentIds) {
-        final Map<String, LiveDocComment> liveDocComments = commentsRenderType == null ? Map.of() : getCommentsFromDocument(document, commentsRenderType.equals(CommentsRenderType.OPEN));
-        List<LiveDocComment> unreferencedComments = liveDocComments.entrySet().stream().filter(entry -> !usedCommentIds.contains(entry.getKey())).map(Map.Entry::getValue).toList();
+    public String addUnreferencedComments(@NotNull String html, @NotNull Map<String, LiveDocComment> liveDocComments, @NotNull Set<String> renderedCommentIds) {
+        List<LiveDocComment> unreferencedComments = liveDocComments.entrySet().stream().filter(entry -> !renderedCommentIds.contains(entry.getKey())).map(Map.Entry::getValue).toList();
         if (!unreferencedComments.isEmpty()) {
             StringBuilder modifiedContent = new StringBuilder(html);
             modifiedContent.append("[span class=unreferenced-comments-delimiter][/span]");

--- a/src/main/resources/webapp/docx-exporter-admin/js/modules/style-packages.js
+++ b/src/main/resources/webapp/docx-exporter-admin/js/modules/style-packages.js
@@ -193,6 +193,7 @@ function saveStylePackage() {
             'template': ChildConfigurations.templateSelect.getSelectedValue(),
             'webhooks': ctx.getCheckboxValueById('webhooks-checkbox') ? ChildConfigurations.webhooksSelect.getSelectedValue() : null,
             'renderComments': ctx.getCheckboxValueById('render-comments') ? RenderComments.renderCommentsSelect.getSelectedValue() : null,
+            'includeUnreferencedComments': ctx.getCheckboxValueById('include-unreferenced-comments'),
             'orientation': ctx.getCheckboxValueById('orientation') ? Orientation.orientationSelect.getSelectedValue() : null,
             'paperSize': ctx.getCheckboxValueById('paper-size') ? PaperSize.paperSizeSelect.getSelectedValue() : null,
             'cutEmptyChapters': ctx.getCheckboxValueById('cut-empty-chapters'),
@@ -259,6 +260,8 @@ function setStylePackage(content) {
     ctx.setCheckboxValueById('render-comments', !!stylePackage.renderComments);
     ctx.getElementById('render-comments').dispatchEvent(new Event('change'));
     RenderComments.renderCommentsSelect.selectValue(stylePackage.renderComments || 'OPEN');
+
+    ctx.setCheckboxValueById('include-unreferenced-comments', !!stylePackage.includeUnreferencedComments);
 
     ctx.setCheckboxValueById('cut-empty-chapters', stylePackage.cutEmptyChapters);
     ctx.setCheckboxValueById('cut-empty-wi-attributes', stylePackage.cutEmptyWorkitemAttributes);

--- a/src/main/resources/webapp/docx-exporter-admin/js/modules/style-packages.js
+++ b/src/main/resources/webapp/docx-exporter-admin/js/modules/style-packages.js
@@ -193,7 +193,7 @@ function saveStylePackage() {
             'template': ChildConfigurations.templateSelect.getSelectedValue(),
             'webhooks': ctx.getCheckboxValueById('webhooks-checkbox') ? ChildConfigurations.webhooksSelect.getSelectedValue() : null,
             'renderComments': ctx.getCheckboxValueById('render-comments') ? RenderComments.renderCommentsSelect.getSelectedValue() : null,
-            'includeUnreferencedComments': ctx.getCheckboxValueById('include-unreferenced-comments'),
+            'includeUnreferencedComments': ctx.getCheckboxValueById('render-comments') && ctx.getCheckboxValueById('include-unreferenced-comments'),
             'orientation': ctx.getCheckboxValueById('orientation') ? Orientation.orientationSelect.getSelectedValue() : null,
             'paperSize': ctx.getCheckboxValueById('paper-size') ? PaperSize.paperSizeSelect.getSelectedValue() : null,
             'cutEmptyChapters': ctx.getCheckboxValueById('cut-empty-chapters'),

--- a/src/main/resources/webapp/docx-exporter-admin/pages/style-packages.jsp
+++ b/src/main/resources/webapp/docx-exporter-admin/pages/style-packages.jsp
@@ -193,10 +193,16 @@
             <div class="flex-column">
                 <div class='checkbox input-group'>
                     <label for='render-comments' id='render-comments-label'>
-                        <input id="render-comments" onchange='document.getElementById("render-comments-select").style.visibility = this.checked ? "visible" : "hidden"' type='checkbox'/>
+                        <input id="render-comments" onchange='document.getElementById("render-comments-select").style.visibility = this.checked ? "visible" : "hidden"; document.getElementById("render-comments-options").style.display = this.checked ? "block" : "none"' type='checkbox'/>
                         Comments rendering
                     </label>
                     <div id="render-comments-select" style="visibility: hidden; margin-left: 10px; width: 200px"></div>
+                </div>
+                <div class='checkbox input-group' id='render-comments-options' style="display: none; padding-left: 20px">
+                    <label for='include-unreferenced-comments' id='include-unreferenced-comments-container' style="display: inline-block" title="Unreferenced comments will be rendered at the end of the document">
+                        <input id="include-unreferenced-comments" type='checkbox' />
+                        include unreferenced
+                    </label>
                 </div>
                 <div class='checkbox input-group'>
                     <label for='cut-empty-wi-attributes'>

--- a/src/main/resources/webapp/docx-exporter-admin/pages/style-packages.jsp
+++ b/src/main/resources/webapp/docx-exporter-admin/pages/style-packages.jsp
@@ -193,7 +193,7 @@
             <div class="flex-column">
                 <div class='checkbox input-group'>
                     <label for='render-comments' id='render-comments-label'>
-                        <input id="render-comments" onchange='document.getElementById("render-comments-select").style.visibility = this.checked ? "visible" : "hidden"; document.getElementById("render-comments-options").style.display = this.checked ? "block" : "none"' type='checkbox'/>
+                        <input id="render-comments" onchange='document.getElementById("render-comments-select").style.visibility = this.checked ? "visible" : "hidden"; document.getElementById("render-comments-options").style.display = this.checked ? "block" : "none"; if (!this.checked) { document.getElementById("include-unreferenced-comments").checked = false; }' type='checkbox'/>
                         Comments rendering
                     </label>
                     <div id="render-comments-select" style="visibility: hidden; margin-left: 10px; width: 200px"></div>

--- a/src/main/resources/webapp/docx-exporter/html/popupForm.html
+++ b/src/main/resources/webapp/docx-exporter/html/popupForm.html
@@ -67,13 +67,19 @@
                 </div>
                 <div class='property-wrapper'>
                     <label for='popup-docx-render-comments'>
-                        <input id='popup-docx-render-comments' onchange='document.getElementById("popup-docx-render-comments-selector").style.visibility = this.checked ? "visible" : "hidden"' type='checkbox'/>
+                        <input id='popup-docx-render-comments' onchange='document.getElementById("popup-docx-render-comments-selector").style.visibility = this.checked ? "visible" : "hidden"; document.getElementById("popup-docx-render-comments-options").style.display = this.checked ? "flex" : "none"' type='checkbox'/>
                         Comments rendering
                     </label>
                     <select id='popup-docx-render-comments-selector' style='width: 100px'>
                         <option value='OPEN'>Open</option>
                         <option value='ALL'>All</option>
                     </select>
+                </div>
+                <div class='property-wrapper' id='popup-docx-render-comments-options' style='display: none; padding-left: 20px'>
+                    <label for='popup-docx-include-unreferenced-comments' id='popup-docx-include-unreferenced-comments-container' title="Unreferenced comments will be rendered at the end of the document">
+                        <input id='popup-docx-include-unreferenced-comments' type='checkbox' />
+                        include unreferenced
+                    </label>
                 </div>
                 <div class='property-wrapper'>
                     <label for='popup-docx-cut-empty-chapters'>

--- a/src/main/resources/webapp/docx-exporter/html/popupForm.html
+++ b/src/main/resources/webapp/docx-exporter/html/popupForm.html
@@ -67,7 +67,7 @@
                 </div>
                 <div class='property-wrapper'>
                     <label for='popup-docx-render-comments'>
-                        <input id='popup-docx-render-comments' onchange='document.getElementById("popup-docx-render-comments-selector").style.visibility = this.checked ? "visible" : "hidden"; document.getElementById("popup-docx-render-comments-options").style.display = this.checked ? "flex" : "none"' type='checkbox'/>
+                        <input id='popup-docx-render-comments' onchange='document.getElementById("popup-docx-render-comments-selector").style.visibility = this.checked ? "visible" : "hidden"; document.getElementById("popup-docx-render-comments-options").style.display = this.checked ? "flex" : "none"; if (!this.checked) { document.getElementById("popup-docx-include-unreferenced-comments").checked = false; }' type='checkbox'/>
                         Comments rendering
                     </label>
                     <select id='popup-docx-render-comments-selector' style='width: 100px'>

--- a/src/main/resources/webapp/docx-exporter/html/sidePanelContent.html
+++ b/src/main/resources/webapp/docx-exporter/html/sidePanelContent.html
@@ -69,13 +69,19 @@
         </div>
         <div class='property-wrapper'>
             <label for='render-comments'>
-                <input id='render-comments' onchange='document.querySelector("#docx-exporter-panel #render-comments-selector").style.display = this.checked ? "block" : "none"' type='checkbox'/>
+                <input id='render-comments' onchange='document.querySelector("#docx-exporter-panel #render-comments-selector").style.display = this.checked ? "block" : "none"; document.querySelector("#docx-exporter-panel #render-comments-options").style.display = this.checked ? "flex" : "none"' type='checkbox'/>
                 Comments rendering
             </label>
             <select id='render-comments-selector' style='display: none'>
                 <option value='OPEN'>Open</option>
                 <option value='ALL'>All</option>
             </select>
+        </div>
+        <div class='property-wrapper' id='render-comments-options' style='display: none; padding-left: 20px'>
+            <label for='include-unreferenced-comments' id='include-unreferenced-comments-container' title="Unreferenced comments will be rendered at the end of the document">
+                <input id='include-unreferenced-comments' type='checkbox' />
+                include unreferenced
+            </label>
         </div>
         <div class='property-wrapper'>
             <label for='docx-cut-empty-chapters'>

--- a/src/main/resources/webapp/docx-exporter/html/sidePanelContent.html
+++ b/src/main/resources/webapp/docx-exporter/html/sidePanelContent.html
@@ -69,7 +69,7 @@
         </div>
         <div class='property-wrapper'>
             <label for='render-comments'>
-                <input id='render-comments' onchange='document.querySelector("#docx-exporter-panel #render-comments-selector").style.display = this.checked ? "block" : "none"; document.querySelector("#docx-exporter-panel #render-comments-options").style.display = this.checked ? "flex" : "none"' type='checkbox'/>
+                <input id='render-comments' onchange='document.querySelector("#docx-exporter-panel #render-comments-selector").style.display = this.checked ? "block" : "none"; document.querySelector("#docx-exporter-panel #render-comments-options").style.display = this.checked ? "flex" : "none"; if (!this.checked) { document.querySelector("#docx-exporter-panel #include-unreferenced-comments").checked = false; }' type='checkbox'/>
                 Comments rendering
             </label>
             <select id='render-comments-selector' style='display: none'>

--- a/src/main/resources/webapp/docx-exporter/js/modules/ExportPanel.js
+++ b/src/main/resources/webapp/docx-exporter/js/modules/ExportPanel.js
@@ -60,6 +60,9 @@ export default class ExportPanel {
         this.ctx.setValue("render-comments-selector", stylePackage.renderComments  || 'OPEN');
         this.ctx.displayIf("render-comments-selector", !!stylePackage.renderComments)
 
+        this.ctx.displayIf("render-comments-options", !!stylePackage.renderComments, "flex")
+        this.ctx.setCheckbox("include-unreferenced-comments", !!stylePackage.includeUnreferencedComments);
+
         this.ctx.setCheckbox("docx-cut-empty-chapters", stylePackage.cutEmptyChapters);
         this.ctx.setCheckbox("docx-cut-empty-wi-attributes", stylePackage.cutEmptyWorkitemAttributes);
         this.ctx.setCheckbox("docx-cut-urls", stylePackage.cutLocalURLs);
@@ -138,6 +141,7 @@ export default class ExportPanel {
             .setWebhooks(this.ctx.getElementById("docx-webhooks-checkbox").checked ? this.ctx.getElementById("docx-webhooks-selector").value : null)
             .setRemovalSelector(this.ctx.getValueById("docx-removal-selector"))
             .setRenderComments(this.ctx.getElementById('render-comments').checked ? this.ctx.getElementById("render-comments-selector").value : null)
+            .setIncludeUnreferencedComments(this.ctx.getElementById('include-unreferenced-comments').checked)
             .setCutEmptyChapters(this.ctx.getElementById("docx-cut-empty-chapters").checked)
             .setCutEmptyWIAttributes(this.ctx.getElementById('docx-cut-empty-wi-attributes').checked)
             .setCutLocalUrls(this.ctx.getElementById("docx-cut-urls").checked)

--- a/src/main/resources/webapp/docx-exporter/js/modules/ExportPanel.js
+++ b/src/main/resources/webapp/docx-exporter/js/modules/ExportPanel.js
@@ -58,9 +58,9 @@ export default class ExportPanel {
 
         this.ctx.setCheckbox("render-comments", !!stylePackage.renderComments);
         this.ctx.setValue("render-comments-selector", stylePackage.renderComments  || 'OPEN');
-        this.ctx.displayIf("render-comments-selector", !!stylePackage.renderComments)
+        this.ctx.displayIf("render-comments-selector", !!stylePackage.renderComments);
 
-        this.ctx.displayIf("render-comments-options", !!stylePackage.renderComments, "flex")
+        this.ctx.displayIf("render-comments-options", !!stylePackage.renderComments, "flex");
         this.ctx.setCheckbox("include-unreferenced-comments", !!stylePackage.includeUnreferencedComments);
 
         this.ctx.setCheckbox("docx-cut-empty-chapters", stylePackage.cutEmptyChapters);

--- a/src/main/resources/webapp/docx-exporter/js/modules/ExportPanel.js
+++ b/src/main/resources/webapp/docx-exporter/js/modules/ExportPanel.js
@@ -141,7 +141,7 @@ export default class ExportPanel {
             .setWebhooks(this.ctx.getElementById("docx-webhooks-checkbox").checked ? this.ctx.getElementById("docx-webhooks-selector").value : null)
             .setRemovalSelector(this.ctx.getValueById("docx-removal-selector"))
             .setRenderComments(this.ctx.getElementById('render-comments').checked ? this.ctx.getElementById("render-comments-selector").value : null)
-            .setIncludeUnreferencedComments(this.ctx.getElementById('include-unreferenced-comments').checked)
+            .setIncludeUnreferencedComments(this.ctx.getElementById('render-comments').checked && this.ctx.getElementById('include-unreferenced-comments').checked)
             .setCutEmptyChapters(this.ctx.getElementById("docx-cut-empty-chapters").checked)
             .setCutEmptyWIAttributes(this.ctx.getElementById('docx-cut-empty-wi-attributes').checked)
             .setCutLocalUrls(this.ctx.getElementById("docx-cut-urls").checked)

--- a/src/main/resources/webapp/docx-exporter/js/modules/ExportParams.js
+++ b/src/main/resources/webapp/docx-exporter/js/modules/ExportParams.js
@@ -36,6 +36,7 @@ export default class ExportParams {
         this.webhooks = builder.webhooks;
         this.removalSelector = builder.removalSelector;
         this.renderComments = builder.renderComments;
+        this.includeUnreferencedComments = builder.includeUnreferencedComments;
         this.cutEmptyChapters = builder.cutEmptyChapters;
         this.cutEmptyWIAttributes = builder.cutEmptyWIAttributes;
         this.cutLocalUrls = builder.cutLocalUrls;
@@ -75,6 +76,7 @@ export default class ExportParams {
                 this.webhooks = undefined;
                 this.removalSelector = undefined;
                 this.renderComments = undefined;
+                this.includeUnreferencedComments = undefined;
                 this.cutEmptyChapters = undefined;
                 this.cutEmptyWIAttributes = undefined;
                 this.cutLocalUrls = undefined;
@@ -140,6 +142,11 @@ export default class ExportParams {
 
             setRenderComments(renderComments) {
                 this.renderComments = renderComments;
+                return this;
+            }
+
+            setIncludeUnreferencedComments(includeUnreferencedComments) {
+                this.includeUnreferencedComments = includeUnreferencedComments;
                 return this;
             }
 

--- a/src/main/resources/webapp/docx-exporter/js/modules/ExportPopup.js
+++ b/src/main/resources/webapp/docx-exporter/js/modules/ExportPopup.js
@@ -358,7 +358,7 @@ export default class ExportPopup {
             .setWebhooks(this.ctx.getElementById("popup-docx-webhooks-checkbox").checked ? this.ctx.getElementById("popup-docx-webhooks-selector").value : null)
             .setRemovalSelector(this.ctx.getValueById("popup-docx-removal-selector"))
             .setRenderComments(this.ctx.getElementById('popup-docx-render-comments').checked ? this.ctx.getElementById("popup-docx-render-comments-selector").value : null)
-            .setIncludeUnreferencedComments(this.ctx.getElementById('popup-docx-include-unreferenced-comments').checked)
+            .setIncludeUnreferencedComments(this.ctx.getElementById('popup-docx-render-comments').checked && this.ctx.getElementById('popup-docx-include-unreferenced-comments').checked)
             .setCutEmptyChapters(this.ctx.getElementById("popup-docx-cut-empty-chapters").checked)
             .setCutEmptyWIAttributes(this.ctx.getElementById('popup-docx-cut-empty-wi-attributes').checked)
             .setCutLocalUrls(this.ctx.getElementById("popup-docx-cut-urls").checked)

--- a/src/main/resources/webapp/docx-exporter/js/modules/ExportPopup.js
+++ b/src/main/resources/webapp/docx-exporter/js/modules/ExportPopup.js
@@ -241,6 +241,9 @@ export default class ExportPopup {
         this.ctx.setValue("popup-docx-render-comments-selector", stylePackage.renderComments || 'OPEN');
         this.ctx.visibleIf("popup-docx-render-comments-selector", !!stylePackage.renderComments);
 
+        this.ctx.displayIf("popup-docx-render-comments-options", !!stylePackage.renderComments, "flex")
+        this.ctx.setCheckbox("popup-docx-include-unreferenced-comments", !!stylePackage.includeUnreferencedComments);
+
         this.ctx.setCheckbox("popup-docx-cut-urls", stylePackage.cutLocalURLs);
         this.ctx.setCheckbox("popup-docx-cut-empty-chapters", stylePackage.cutEmptyChapters);
         this.ctx.setCheckbox("popup-docx-cut-empty-wi-attributes", stylePackage.cutEmptyWorkitemAttributes);
@@ -355,6 +358,7 @@ export default class ExportPopup {
             .setWebhooks(this.ctx.getElementById("popup-docx-webhooks-checkbox").checked ? this.ctx.getElementById("popup-docx-webhooks-selector").value : null)
             .setRemovalSelector(this.ctx.getValueById("popup-docx-removal-selector"))
             .setRenderComments(this.ctx.getElementById('popup-docx-render-comments').checked ? this.ctx.getElementById("popup-docx-render-comments-selector").value : null)
+            .setIncludeUnreferencedComments(this.ctx.getElementById('popup-docx-include-unreferenced-comments').checked)
             .setCutEmptyChapters(this.ctx.getElementById("popup-docx-cut-empty-chapters").checked)
             .setCutEmptyWIAttributes(this.ctx.getElementById('popup-docx-cut-empty-wi-attributes').checked)
             .setCutLocalUrls(this.ctx.getElementById("popup-docx-cut-urls").checked)

--- a/src/main/resources/webapp/docx-exporter/js/modules/ExportPopup.js
+++ b/src/main/resources/webapp/docx-exporter/js/modules/ExportPopup.js
@@ -241,7 +241,7 @@ export default class ExportPopup {
         this.ctx.setValue("popup-docx-render-comments-selector", stylePackage.renderComments || 'OPEN');
         this.ctx.visibleIf("popup-docx-render-comments-selector", !!stylePackage.renderComments);
 
-        this.ctx.displayIf("popup-docx-render-comments-options", !!stylePackage.renderComments, "flex")
+        this.ctx.displayIf("popup-docx-render-comments-options", !!stylePackage.renderComments, "flex");
         this.ctx.setCheckbox("popup-docx-include-unreferenced-comments", !!stylePackage.includeUnreferencedComments);
 
         this.ctx.setCheckbox("popup-docx-cut-urls", stylePackage.cutLocalURLs);

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/DocxExporterFormExtensionTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/DocxExporterFormExtensionTest.java
@@ -66,6 +66,30 @@ class DocxExporterFormExtensionTest {
     }
 
     @Test
+    void testAdjustRenderComments() {
+        DocxExporterFormExtension extension = new DocxExporterFormExtension();
+        String form = "<input id='render-comments'/>"
+                + "<select id='render-comments-selector' style='display: none'><option value='ALL'></select>"
+                + "<div id='render-comments-options' style='display: none'>"
+                + "<input id='include-unreferenced-comments'/></div>";
+        StylePackageModel packageModel = new StylePackageModel();
+        assertThat(extension.adjustRenderComments(form, packageModel)).isEqualTo(form);
+
+        packageModel.setRenderComments(CommentsRenderType.ALL);
+        assertThat(extension.adjustRenderComments(form, packageModel))
+                .contains("<input id='render-comments' checked")
+                .contains("id='render-comments-options' style='display: flex")
+                .contains("<input id='include-unreferenced-comments'/>")
+                .doesNotContain("<input id='include-unreferenced-comments' checked");
+
+        packageModel.setIncludeUnreferencedComments(true);
+        assertThat(extension.adjustRenderComments(form, packageModel))
+                .contains("<input id='render-comments' checked")
+                .contains("id='render-comments-options' style='display: flex")
+                .contains("<input id='include-unreferenced-comments' checked");
+    }
+
+    @Test
     void adjustLinkRolesShouldHideFieldsWhenNoRolesAvailable() {
         DocxExporterFormExtension extension = new DocxExporterFormExtension();
         String form = buildRolesFormFragment();

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/rest/model/documents/adapters/LiveDocAdapterTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/rest/model/documents/adapters/LiveDocAdapterTest.java
@@ -35,7 +35,7 @@ class LiveDocAdapterTest {
         workItemCommentsProcessorMockedConstruction = mockConstruction(WorkItemCommentsProcessor.class,
                 (mock, context) -> when(mock.addWorkItemComments(any(), anyString(), anyBoolean())).thenAnswer(invocation -> invocation.getArgument(1)));
         liveDocCommentsProcessorMockedConstruction = mockConstruction(LiveDocCommentsProcessor.class,
-                (mock, context) -> when(mock.addLiveDocComments(any(), anyString(), nullable(CommentsRenderType.class), any())).thenAnswer(invocation -> invocation.getArgument(1)));
+                (mock, context) -> when(mock.addLiveDocComments(anyString(), any(), any())).thenAnswer(invocation -> invocation.getArgument(0)));
         documentRendererMockedConstruction = mockConstruction(ModifiedDocumentRenderer.class,
                 (mock, context) -> when(mock.render(nullable(String.class))).thenAnswer(invocation -> renderedContent));
     }

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/rest/model/documents/adapters/LiveDocAdapterTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/rest/model/documents/adapters/LiveDocAdapterTest.java
@@ -35,7 +35,7 @@ class LiveDocAdapterTest {
         workItemCommentsProcessorMockedConstruction = mockConstruction(WorkItemCommentsProcessor.class,
                 (mock, context) -> when(mock.addWorkItemComments(any(), anyString(), anyBoolean())).thenAnswer(invocation -> invocation.getArgument(1)));
         liveDocCommentsProcessorMockedConstruction = mockConstruction(LiveDocCommentsProcessor.class,
-                (mock, context) -> when(mock.addLiveDocComments(any(), anyString(), nullable(CommentsRenderType.class))).thenAnswer(invocation -> invocation.getArgument(1)));
+                (mock, context) -> when(mock.addLiveDocComments(any(), anyString(), nullable(CommentsRenderType.class), any())).thenAnswer(invocation -> invocation.getArgument(1)));
         documentRendererMockedConstruction = mockConstruction(ModifiedDocumentRenderer.class,
                 (mock, context) -> when(mock.render(nullable(String.class))).thenAnswer(invocation -> renderedContent));
     }

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/settings/StylePackageSettingsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/settings/StylePackageSettingsTest.java
@@ -88,6 +88,16 @@ class StylePackageSettingsTest {
 
             assertNull(loadedModel.getRenderComments());
             assertNull(loadedModel.getLinkRoleDirection());
+            assertFalse(loadedModel.isIncludeUnreferencedComments());
+
+            // check includeUnreferencedComments round-trip
+            customProjectModel.setIncludeUnreferencedComments(true);
+            when(mockedSettingsService.read(eq(mockProjectLocation), any())).thenReturn(customProjectModel.serialize());
+            assertTrue(stylePackageSettings.load(projectName, SettingId.fromName("Any setting name")).isIncludeUnreferencedComments());
+
+            customProjectModel.setIncludeUnreferencedComments(false);
+            when(mockedSettingsService.read(eq(mockProjectLocation), any())).thenReturn(customProjectModel.serialize());
+            assertFalse(stylePackageSettings.load(projectName, SettingId.fromName("Any setting name")).isIncludeUnreferencedComments());
         }
     }
 

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/LiveDocCommentsProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/LiveDocCommentsProcessorTest.java
@@ -1,5 +1,6 @@
 package ch.sbb.polarion.extension.docx_exporter.util;
 
+import ch.sbb.polarion.extension.docx_exporter.model.LiveDocComment;
 import ch.sbb.polarion.extension.docx_exporter.rest.model.conversion.CommentsRenderType;
 import com.polarion.alm.server.api.model.document.ProxyDocument;
 import com.polarion.alm.shared.api.model.comment.CommentBase;
@@ -13,11 +14,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.text.SimpleDateFormat;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -56,6 +59,8 @@ class LiveDocCommentsProcessorTest {
         when(comments.iterator()).thenReturn(commentBases.iterator());
 
         // resolved comment isn't rendered
+        LiveDocCommentsProcessor openProcessor = new LiveDocCommentsProcessor();
+        Map<String, LiveDocComment> openComments = openProcessor.getLiveDocComments(document, CommentsRenderType.OPEN);
         assertEquals("""
                 <div>some content1</div>
                 [span class=comment level-0][span class=meta][span class=date]2025-03-13 16:21[/span][span class=author]author1[/span][/span][span class=text]text1[/span][/span]
@@ -64,11 +69,13 @@ class LiveDocCommentsProcessorTest {
                 <div>some content3</div>
                 [span class=comment level-0][span class=meta][span class=date]2025-03-13 16:23[/span][span class=author]author3[/span][/span][span class=text]text3[/span][/span]
                 <div>some content4</div>
-                """, new LiveDocCommentsProcessor().addLiveDocComments(document, html, CommentsRenderType.OPEN, new HashSet<>()));
+                """, openProcessor.addLiveDocComments(html, openComments, new HashSet<>()));
 
         when(comments.iterator()).thenReturn(commentBases.iterator());
 
         // now resolved comment is here
+        LiveDocCommentsProcessor allProcessor = new LiveDocCommentsProcessor();
+        Map<String, LiveDocComment> allComments = allProcessor.getLiveDocComments(document, CommentsRenderType.ALL);
         assertEquals("""
                 <div>some content1</div>
                 [span class=comment level-0][span class=meta][span class=date]2025-03-13 16:21[/span][span class=author]author1[/span][/span][span class=text]text1[/span][/span]
@@ -77,12 +84,12 @@ class LiveDocCommentsProcessorTest {
                 <div>some content3</div>
                 [span class=comment level-0][span class=meta][span class=date]2025-03-13 16:23[/span][span class=author]author3[/span][/span][span class=text]text3[/span][/span]
                 <div>some content4</div>
-                """, new LiveDocCommentsProcessor().addLiveDocComments(document, html, CommentsRenderType.ALL, new HashSet<>()));
+                """, allProcessor.addLiveDocComments(html, allComments, new HashSet<>()));
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    void addLiveDocCommentsPopulatesUsedCommentIds() {
+    void addLiveDocCommentsPopulatesRenderedCommentIds() {
         ProxyDocument document = mock(ProxyDocument.class, RETURNS_DEEP_STUBS);
 
         UpdatableDocumentFields fields = mock(UpdatableDocumentFields.class);
@@ -104,10 +111,12 @@ class LiveDocCommentsProcessorTest {
         );
         when(comments.iterator()).thenReturn(commentBases.iterator());
 
-        Set<String> usedCommentIds = new HashSet<>();
-        new LiveDocCommentsProcessor().addLiveDocComments(document, html, CommentsRenderType.OPEN, usedCommentIds);
+        Set<String> renderedCommentIds = new HashSet<>();
+        LiveDocCommentsProcessor processor = new LiveDocCommentsProcessor();
+        Map<String, LiveDocComment> liveDocComments = processor.getLiveDocComments(document, CommentsRenderType.OPEN);
+        processor.addLiveDocComments(html, liveDocComments, renderedCommentIds);
 
-        assertEquals(Set.of("1", "3"), usedCommentIds);
+        assertEquals(Set.of("1", "3"), renderedCommentIds);
     }
 
     @Test
@@ -128,10 +137,12 @@ class LiveDocCommentsProcessorTest {
         );
         when(comments.iterator()).thenReturn(commentBases.iterator());
 
-        Set<String> usedCommentIds = new HashSet<>(Set.of("1"));
+        Set<String> renderedCommentIds = new HashSet<>(Set.of("1"));
         String html = "<div>content</div>";
 
-        String result = new LiveDocCommentsProcessor().addUnreferencedComments(document, html, CommentsRenderType.OPEN, usedCommentIds);
+        LiveDocCommentsProcessor processor = new LiveDocCommentsProcessor();
+        Map<String, LiveDocComment> liveDocComments = processor.getLiveDocComments(document, CommentsRenderType.OPEN);
+        String result = processor.addUnreferencedComments(html, liveDocComments, renderedCommentIds);
 
         assertTrue(result.startsWith("<div>content</div>"));
         assertTrue(result.contains("[span class=unreferenced-comments-delimiter][/span]"));
@@ -155,10 +166,12 @@ class LiveDocCommentsProcessorTest {
         );
         when(comments.iterator()).thenReturn(commentBases.iterator());
 
-        Set<String> usedCommentIds = new HashSet<>(Set.of("1"));
+        Set<String> renderedCommentIds = new HashSet<>(Set.of("1"));
         String html = "<div>content</div>";
 
-        String result = new LiveDocCommentsProcessor().addUnreferencedComments(document, html, CommentsRenderType.OPEN, usedCommentIds);
+        LiveDocCommentsProcessor processor = new LiveDocCommentsProcessor();
+        Map<String, LiveDocComment> liveDocComments = processor.getLiveDocComments(document, CommentsRenderType.OPEN);
+        String result = processor.addUnreferencedComments(html, liveDocComments, renderedCommentIds);
 
         assertEquals(html, result);
     }
@@ -180,21 +193,25 @@ class LiveDocCommentsProcessorTest {
         );
         when(comments.iterator()).thenReturn(commentBases.iterator());
 
-        String result = new LiveDocCommentsProcessor().addUnreferencedComments(document, "<div>content</div>", CommentsRenderType.OPEN, new HashSet<>());
+        LiveDocCommentsProcessor processor = new LiveDocCommentsProcessor();
+        Map<String, LiveDocComment> liveDocComments = processor.getLiveDocComments(document, CommentsRenderType.OPEN);
+        String result = processor.addUnreferencedComments("<div>content</div>", liveDocComments, new HashSet<>());
 
         assertTrue(result.contains("text1"));
         // OPEN preference must exclude the resolved unreferenced comment
-        org.junit.jupiter.api.Assertions.assertFalse(result.contains("text2-resolved"));
+        assertFalse(result.contains("text2-resolved"));
     }
 
     @Test
     void addUnreferencedCommentsReturnsOriginalWhenNullRenderType() {
         ProxyDocument document = mock(ProxyDocument.class, RETURNS_DEEP_STUBS);
 
-        Set<String> usedCommentIds = new HashSet<>();
+        Set<String> renderedCommentIds = new HashSet<>();
         String html = "<div>content</div>";
 
-        String result = new LiveDocCommentsProcessor().addUnreferencedComments(document, html, null, usedCommentIds);
+        LiveDocCommentsProcessor processor = new LiveDocCommentsProcessor();
+        Map<String, LiveDocComment> liveDocComments = processor.getLiveDocComments(document, null);
+        String result = processor.addUnreferencedComments(html, liveDocComments, renderedCommentIds);
 
         assertEquals(html, result);
     }

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/LiveDocCommentsProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/LiveDocCommentsProcessorTest.java
@@ -11,11 +11,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.text.SimpleDateFormat;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -61,7 +64,7 @@ class LiveDocCommentsProcessorTest {
                 <div>some content3</div>
                 [span class=comment level-0][span class=meta][span class=date]2025-03-13 16:23[/span][span class=author]author3[/span][/span][span class=text]text3[/span][/span]
                 <div>some content4</div>
-                """, new LiveDocCommentsProcessor().addLiveDocComments(document, html, CommentsRenderType.OPEN));
+                """, new LiveDocCommentsProcessor().addLiveDocComments(document, html, CommentsRenderType.OPEN, new HashSet<>()));
 
         when(comments.iterator()).thenReturn(commentBases.iterator());
 
@@ -74,7 +77,126 @@ class LiveDocCommentsProcessorTest {
                 <div>some content3</div>
                 [span class=comment level-0][span class=meta][span class=date]2025-03-13 16:23[/span][span class=author]author3[/span][/span][span class=text]text3[/span][/span]
                 <div>some content4</div>
-                """, new LiveDocCommentsProcessor().addLiveDocComments(document, html, CommentsRenderType.ALL));
+                """, new LiveDocCommentsProcessor().addLiveDocComments(document, html, CommentsRenderType.ALL, new HashSet<>()));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void addLiveDocCommentsPopulatesUsedCommentIds() {
+        ProxyDocument document = mock(ProxyDocument.class, RETURNS_DEEP_STUBS);
+
+        UpdatableDocumentFields fields = mock(UpdatableDocumentFields.class);
+        CommentBasesTreeField<CommentBase> comments = mock(CommentBasesTreeField.class);
+        doCallRealMethod().when(comments).forEach(any(Consumer.class));
+        when(fields.comments()).thenReturn(comments);
+        when(document.fields()).thenReturn(fields);
+
+        String html = """
+                <div>content</div>
+                <span id="polarion-comment:1"></span>
+                <div>more</div>
+                <img id="polarion-comment:3" class="polarion-dle-comment-icon"/>
+                """;
+
+        List<CommentBase> commentBases = List.of(
+                mockComment("1", "text1", "author1", false),
+                mockComment("3", "text3", "author3", false)
+        );
+        when(comments.iterator()).thenReturn(commentBases.iterator());
+
+        Set<String> usedCommentIds = new HashSet<>();
+        new LiveDocCommentsProcessor().addLiveDocComments(document, html, CommentsRenderType.OPEN, usedCommentIds);
+
+        assertEquals(Set.of("1", "3"), usedCommentIds);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void addUnreferencedCommentsAppendsWhenUnreferencedExist() {
+        ProxyDocument document = mock(ProxyDocument.class, RETURNS_DEEP_STUBS);
+
+        UpdatableDocumentFields fields = mock(UpdatableDocumentFields.class);
+        CommentBasesTreeField<CommentBase> comments = mock(CommentBasesTreeField.class);
+        doCallRealMethod().when(comments).forEach(any(Consumer.class));
+        when(fields.comments()).thenReturn(comments);
+        when(document.fields()).thenReturn(fields);
+
+        List<CommentBase> commentBases = List.of(
+                mockComment("1", "text1", "author1", false),
+                mockComment("2", "text2", "author2", false),
+                mockComment("3", "text3", "author3", false)
+        );
+        when(comments.iterator()).thenReturn(commentBases.iterator());
+
+        Set<String> usedCommentIds = new HashSet<>(Set.of("1"));
+        String html = "<div>content</div>";
+
+        String result = new LiveDocCommentsProcessor().addUnreferencedComments(document, html, CommentsRenderType.OPEN, usedCommentIds);
+
+        assertTrue(result.startsWith("<div>content</div>"));
+        assertTrue(result.contains("[span class=unreferenced-comments-delimiter][/span]"));
+        assertTrue(result.contains("text2"));
+        assertTrue(result.contains("text3"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void addUnreferencedCommentsReturnsOriginalWhenAllReferenced() {
+        ProxyDocument document = mock(ProxyDocument.class, RETURNS_DEEP_STUBS);
+
+        UpdatableDocumentFields fields = mock(UpdatableDocumentFields.class);
+        CommentBasesTreeField<CommentBase> comments = mock(CommentBasesTreeField.class);
+        doCallRealMethod().when(comments).forEach(any(Consumer.class));
+        when(fields.comments()).thenReturn(comments);
+        when(document.fields()).thenReturn(fields);
+
+        List<CommentBase> commentBases = List.of(
+                mockComment("1", "text1", "author1", false)
+        );
+        when(comments.iterator()).thenReturn(commentBases.iterator());
+
+        Set<String> usedCommentIds = new HashSet<>(Set.of("1"));
+        String html = "<div>content</div>";
+
+        String result = new LiveDocCommentsProcessor().addUnreferencedComments(document, html, CommentsRenderType.OPEN, usedCommentIds);
+
+        assertEquals(html, result);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void addUnreferencedCommentsRespectsOpenPreference() {
+        ProxyDocument document = mock(ProxyDocument.class, RETURNS_DEEP_STUBS);
+
+        UpdatableDocumentFields fields = mock(UpdatableDocumentFields.class);
+        CommentBasesTreeField<CommentBase> comments = mock(CommentBasesTreeField.class);
+        doCallRealMethod().when(comments).forEach(any(Consumer.class));
+        when(fields.comments()).thenReturn(comments);
+        when(document.fields()).thenReturn(fields);
+
+        List<CommentBase> commentBases = List.of(
+                mockComment("1", "text1", "author1", false),
+                mockComment("2", "text2-resolved", "author2", true)
+        );
+        when(comments.iterator()).thenReturn(commentBases.iterator());
+
+        String result = new LiveDocCommentsProcessor().addUnreferencedComments(document, "<div>content</div>", CommentsRenderType.OPEN, new HashSet<>());
+
+        assertTrue(result.contains("text1"));
+        // OPEN preference must exclude the resolved unreferenced comment
+        org.junit.jupiter.api.Assertions.assertFalse(result.contains("text2-resolved"));
+    }
+
+    @Test
+    void addUnreferencedCommentsReturnsOriginalWhenNullRenderType() {
+        ProxyDocument document = mock(ProxyDocument.class, RETURNS_DEEP_STUBS);
+
+        Set<String> usedCommentIds = new HashSet<>();
+        String html = "<div>content</div>";
+
+        String result = new LiveDocCommentsProcessor().addUnreferencedComments(document, html, null, usedCommentIds);
+
+        assertEquals(html, result);
     }
 
     @SneakyThrows


### PR DESCRIPTION
Refs: #214

### Proposed changes

It would be great to have an ability to export unreferenced comments.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
