### PR TITLE
fix: handle unknown MIME types gracefully in DocxExporter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -167,6 +167,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -215,6 +216,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/DocxExporterFileResourceProvider.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/DocxExporterFileResourceProvider.java
@@ -61,9 +61,17 @@ public class DocxExporterFileResourceProvider implements FileResourceProvider {
         byte[] resourceBytes = getResourceAsBytes(resource);
         if (resourceBytes != null && resourceBytes.length != 0) { // Don't make any manipulations if resource wasn't resolved
             String mimeType = MediaUtils.guessMimeType(resource, resourceBytes);
+            if (mimeType == null) {
+                // No detector recognized the content; skip inlining so the original URL stays in the HTML
+                // instead of producing a broken `data:null;base64,...` URL. guessMimeType has already logged the cause.
+                return null;
+            }
             if (MIME_TYPE_SVG.equals(mimeType)) {
                 // Additional check to verify that the content is indeed an SVG
-                mimeType = MediaUtils.getMimeTypeUsingTikaByContent(resource, resourceBytes);
+                String refinedMimeType = MediaUtils.getMimeTypeUsingTikaByContent(resource, resourceBytes);
+                if (refinedMimeType != null) {
+                    mimeType = refinedMimeType;
+                }
             }
             return String.format("data:%s;base64,%s", mimeType, Base64.getEncoder().encodeToString(resourceBytes));
         }

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/MediaUtils.java
@@ -176,14 +176,21 @@ public class MediaUtils {
         return Files.probeContentType(Paths.get(resource));
     }
 
-    @SuppressWarnings("unchecked")
     public String getMimeTypeUsingTikaByResourceName(@NotNull String resource, byte[] resourceBytes) {
-        return ((Optional<String>) BundleJarsPrioritizingRunnable.executeCached(TikaMimeTypeResolver.class, Map.of(PARAM_VALUE, resource)).get(PARAM_RESULT)).orElse(null);
+        return detectMimeTypeWithTika(Map.of(PARAM_VALUE, resource));
     }
 
-    @SuppressWarnings("unchecked")
     public String getMimeTypeUsingTikaByContent(@NotNull String resource, byte[] resourceBytes) {
-        return ((Optional<String>) BundleJarsPrioritizingRunnable.executeCached(TikaMimeTypeResolver.class, Map.of(PARAM_VALUE, resourceBytes)).get(PARAM_RESULT)).orElse(null);
+        return detectMimeTypeWithTika(Map.of(PARAM_VALUE, resourceBytes));
+    }
+
+    // BundleJarsPrioritizingRunnable.executeCached returns a map without PARAM_RESULT when the runnable itself couldn't
+    // be executed (classloader/reflection/serialization failure — see BundleJarsPrioritizingRunnable.ERROR_KEY). Guard
+    // against that so a diagnostic fallback returns null instead of triggering a NullPointerException.
+    @Nullable
+    private String detectMimeTypeWithTika(@NotNull Map<String, Object> params) {
+        Object result = BundleJarsPrioritizingRunnable.executeCached(TikaMimeTypeResolver.class, params).get(PARAM_RESULT);
+        return result instanceof Optional<?> optional ? (String) optional.orElse(null) : null;
     }
 
     @SneakyThrows

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/TikaMimeTypeResolver.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/TikaMimeTypeResolver.java
@@ -1,6 +1,7 @@
 package ch.sbb.polarion.extension.docx_exporter.util;
 
 import ch.sbb.polarion.extension.generic.util.BundleJarsPrioritizingRunnable;
+import com.polarion.core.util.logging.Logger;
 import org.apache.tika.Tika;
 import org.apache.tika.mime.MimeTypes;
 
@@ -15,17 +16,26 @@ public class TikaMimeTypeResolver implements BundleJarsPrioritizingRunnable {
     public static final String PARAM_VALUE = "value";
     public static final String PARAM_RESULT = "result";
 
+    private static final Logger logger = Logger.getLogger(TikaMimeTypeResolver.class);
+
     private final Tika tika = new Tika();
 
     @Override
     public Map<String, Object> run(Map<String, Object> map) {
-        Object value = map.get(PARAM_VALUE);
-
-        // Currently we can handle String (file names) or byte[] (file content)
-        String detected = value instanceof String stringValue ? tika.detect(stringValue) : tika.detect((byte[]) value);
-
-        // Ignore 'application/octet-stream' fallback
-        return Map.of(PARAM_RESULT, Optional.ofNullable(MimeTypes.OCTET_STREAM.equals(detected) ? null : detected));
+        // Always return a map containing PARAM_RESULT. If detection fails we log the cause and return an empty Optional,
+        // so callers never have to guard against a missing key (which previously caused NPE downstream).
+        Optional<String> detectedMimeType = Optional.empty();
+        try {
+            Object value = map.get(PARAM_VALUE);
+            String detected = value instanceof String stringValue ? tika.detect(stringValue) : tika.detect((byte[]) value);
+            // Ignore 'application/octet-stream' fallback
+            if (!MimeTypes.OCTET_STREAM.equals(detected)) {
+                detectedMimeType = Optional.ofNullable(detected);
+            }
+        } catch (Exception e) {
+            logger.error("Tika failed to detect mime type", e);
+        }
+        return Map.of(PARAM_RESULT, detectedMimeType);
     }
 
 }

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/DocxExporterFileResourceProviderTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/DocxExporterFileResourceProviderTest.java
@@ -68,6 +68,42 @@ class DocxExporterFileResourceProviderTest {
     }
 
     @Test
+    void getResourceAsBase64StringReturnsNullWhenMimeTypeUnknown() {
+        // Regression for #207, #219: if no detector recognizes the content, skip inlining instead of producing
+        // a broken `data:null;base64,...` URL. Returning null leaves the original <img src="..."> in the HTML.
+        DocxExporterFileResourceProvider providerSpy = mock(DocxExporterFileResourceProvider.class);
+        byte[] content = new byte[]{1, 2, 3};
+        when(providerSpy.getResourceAsBytes("unknown.bin")).thenReturn(content);
+        when(providerSpy.getResourceAsBase64String(any())).thenCallRealMethod();
+
+        try (MockedStatic<MediaUtils> mockedMediaUtils = mockStatic(MediaUtils.class)) {
+            mockedMediaUtils.when(() -> MediaUtils.isDataUrl("unknown.bin")).thenReturn(false);
+            mockedMediaUtils.when(() -> MediaUtils.guessMimeType("unknown.bin", content)).thenReturn(null);
+
+            assertNull(providerSpy.getResourceAsBase64String("unknown.bin"));
+        }
+    }
+
+    @Test
+    void getResourceAsBase64StringKeepsSvgMimeWhenTikaRefinementReturnsNull() {
+        // If guessMimeType says SVG but the refinement Tika call returns null (executor failure / Tika threw),
+        // we must keep the original SVG mime instead of overwriting it with null and producing `data:null;...`.
+        DocxExporterFileResourceProvider providerSpy = mock(DocxExporterFileResourceProvider.class);
+        byte[] svgContent = "<svg></svg>".getBytes(StandardCharsets.UTF_8);
+        when(providerSpy.getResourceAsBytes("img.svg")).thenReturn(svgContent);
+        when(providerSpy.getResourceAsBase64String(any())).thenCallRealMethod();
+
+        try (MockedStatic<MediaUtils> mockedMediaUtils = mockStatic(MediaUtils.class)) {
+            mockedMediaUtils.when(() -> MediaUtils.isDataUrl("img.svg")).thenReturn(false);
+            mockedMediaUtils.when(() -> MediaUtils.guessMimeType("img.svg", svgContent)).thenReturn("image/svg+xml");
+            mockedMediaUtils.when(() -> MediaUtils.getMimeTypeUsingTikaByContent("img.svg", svgContent)).thenReturn(null);
+
+            String result = providerSpy.getResourceAsBase64String("img.svg");
+            assertEquals("data:image/svg+xml;base64," + Base64.getEncoder().encodeToString(svgContent), result);
+        }
+    }
+
+    @Test
     @SneakyThrows
     void getResourceAsBytesSuccess() {
         when(resolverMock.canResolve(TEST_RESOURCE)).thenReturn(true);

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/MediaUtilsExecutorFailureTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/MediaUtilsExecutorFailureTest.java
@@ -1,0 +1,29 @@
+package ch.sbb.polarion.extension.docx_exporter.util;
+
+import ch.sbb.polarion.extension.generic.util.BundleJarsPrioritizingRunnable;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+
+class MediaUtilsExecutorFailureTest {
+
+    // Regression test for issue #207: when BundleJarsPrioritizingRunnableExecutor catches an internal exception
+    // (classloader / reflection / serialization failure), it returns Map.of(ERROR_KEY, e) with no PARAM_RESULT.
+    // MediaUtils must degrade to null instead of triggering a NullPointerException on Optional.orElse().
+    @Test
+    void getMimeTypeUsingTika_whenExecutorReturnsErrorMap_returnsNullWithoutNpe() {
+        Map<String, Object> errorOnly = Map.of(BundleJarsPrioritizingRunnable.ERROR_KEY, new RuntimeException("executor failed"));
+
+        try (MockedStatic<BundleJarsPrioritizingRunnable> mocked = mockStatic(BundleJarsPrioritizingRunnable.class)) {
+            mocked.when(() -> BundleJarsPrioritizingRunnable.executeCached(any(), any())).thenReturn(errorOnly);
+
+            assertNull(MediaUtils.getMimeTypeUsingTikaByContent("some.svg", new byte[]{1, 2, 3}));
+            assertNull(MediaUtils.getMimeTypeUsingTikaByResourceName("some.svg", null));
+        }
+    }
+}

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/TikaMimeTypeResolverTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/TikaMimeTypeResolverTest.java
@@ -131,6 +131,28 @@ class TikaMimeTypeResolverTest {
 
 
     @Test
+    void testRunSwallowsExceptionsAndReturnsEmptyOptional() {
+        // Passing an unsupported type (neither String nor byte[]) makes the byte[] cast throw ClassCastException inside run().
+        // That exception must be caught so the returned map always contains PARAM_RESULT and downstream callers never NPE.
+        Map<String, Object> input = Map.of(TikaMimeTypeResolver.PARAM_VALUE, 42);
+        Map<String, Object> result = resolver.run(input);
+
+        assertThat(result).containsKey(TikaMimeTypeResolver.PARAM_RESULT);
+        Optional<String> mimeType = (Optional<String>) result.get(TikaMimeTypeResolver.PARAM_RESULT);
+        assertThat(mimeType).isEmpty();
+    }
+
+    @Test
+    void testRunWithMissingValueReturnsEmptyOptional() {
+        // No PARAM_VALUE at all — internal null dereference must also be caught.
+        Map<String, Object> result = resolver.run(Map.of());
+
+        assertThat(result).containsKey(TikaMimeTypeResolver.PARAM_RESULT);
+        Optional<String> mimeType = (Optional<String>) result.get(TikaMimeTypeResolver.PARAM_RESULT);
+        assertThat(mimeType).isEmpty();
+    }
+
+    @Test
     void testRunWithJavaScriptFileName() {
         Map<String, Object> input = Map.of(TikaMimeTypeResolver.PARAM_VALUE, "script.js");
         Map<String, Object> result = resolver.run(input);


### PR DESCRIPTION
### Proposed changes

This pull request improves the robustness of MIME type detection and handling in the DOCX exporter, preventing downstream errors (such as `NullPointerException`) when MIME type detection fails. The changes ensure that failures in the detection pipeline are gracefully handled and logged, and that invalid or unknown MIME types do not result in malformed data URLs in the output. Additional regression tests are included to verify this behavior.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
