### PR TITLE
fix: when author of a comment was deleted as a user in polarion generation of docx fails

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/LiveDocCommentsProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/LiveDocCommentsProcessor.java
@@ -138,7 +138,7 @@ public class LiveDocCommentsProcessor {
     private CommentData getCommentData(LiveDocComment liveDocComment) {
         String date = new SimpleDateFormat("yyyy-MM-dd HH:mm").format(liveDocComment.getCreated().get());
         User user = liveDocComment.getAuthor().get();
-        String authorName = user != null ? user.fields().name().get() : null;
+        String authorName = user != null ? (user.isUnresolvable() ? user.label() : user.fields().name().get()) : null;
         String commentText = liveDocComment.getText().persistedHtml();
         boolean resolved = liveDocComment.getResolved().get();
         return CommentData.builder()

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/LiveDocCommentsProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/LiveDocCommentsProcessor.java
@@ -138,7 +138,7 @@ public class LiveDocCommentsProcessor {
     private CommentData getCommentData(LiveDocComment liveDocComment) {
         String date = new SimpleDateFormat("yyyy-MM-dd HH:mm").format(liveDocComment.getCreated().get());
         User user = liveDocComment.getAuthor().get();
-        String authorName = user != null ? (user.isUnresolvable() ? user.label() : user.fields().name().get()) : null;
+        String authorName = user != null ? getUserName(user) : null;
         String commentText = liveDocComment.getText().persistedHtml();
         boolean resolved = liveDocComment.getResolved().get();
         return CommentData.builder()
@@ -147,6 +147,10 @@ public class LiveDocCommentsProcessor {
                 .text(commentText)
                 .resolved(resolved)
                 .build();
+    }
+
+    private String getUserName(@NotNull User user) {
+        return user.isUnresolvable() ? user.label() : user.fields().name().get();
     }
 
     @Data

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/LiveDocCommentsProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/LiveDocCommentsProcessorTest.java
@@ -6,6 +6,7 @@ import com.polarion.alm.server.api.model.document.ProxyDocument;
 import com.polarion.alm.shared.api.model.comment.CommentBase;
 import com.polarion.alm.shared.api.model.comment.CommentBasesTreeField;
 import com.polarion.alm.shared.api.model.document.UpdatableDocumentFields;
+import com.polarion.alm.shared.api.model.user.User;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -214,6 +215,36 @@ class LiveDocCommentsProcessorTest {
         String result = processor.addUnreferencedComments(html, liveDocComments, renderedCommentIds);
 
         assertEquals(html, result);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void addLiveDocCommentsRendersUnresolvableUserLabel() {
+        ProxyDocument document = mock(ProxyDocument.class, RETURNS_DEEP_STUBS);
+
+        UpdatableDocumentFields fields = mock(UpdatableDocumentFields.class);
+        CommentBasesTreeField<CommentBase> comments = mock(CommentBasesTreeField.class);
+        doCallRealMethod().when(comments).forEach(any(Consumer.class));
+        when(fields.comments()).thenReturn(comments);
+        when(document.fields()).thenReturn(fields);
+
+        CommentBase commentBase = mockComment("1", "text1", "irrelevant-name", false);
+        User user = Objects.requireNonNull(commentBase.fields().author().get());
+        when(user.isUnresolvable()).thenReturn(true);
+        when(user.label()).thenReturn("deleted-user-label");
+        when(comments.iterator()).thenReturn(List.of(commentBase).iterator());
+
+        String html = """
+                <div>some content</div>
+                <span id="polarion-comment:1"></span>
+                """;
+
+        LiveDocCommentsProcessor processor = new LiveDocCommentsProcessor();
+        Map<String, LiveDocComment> liveDocComments = processor.getLiveDocComments(document, CommentsRenderType.ALL);
+        String result = processor.addLiveDocComments(html, liveDocComments, new HashSet<>());
+
+        assertTrue(result.contains("[span class=author]deleted-user-label[/span]"));
+        assertFalse(result.contains("irrelevant-name"));
     }
 
     @SneakyThrows


### PR DESCRIPTION
### Proposed changes

At the moment when author of a comment was deleted as a user in Polarion, generation of docx fails. This PR fixes this

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
