### PR TITLE
fix: change divs wrapping Linked WorkItem roles by spans to allow them to be inlined

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessor.java
@@ -164,6 +164,9 @@ public class HtmlProcessor {
             timedIfNotNull(generationLog, "Filter tabular linked work items", () -> filterTabularLinkedWorkItems(document, selectedRoleEnumValues));
             timedIfNotNull(generationLog, "Filter non-tabular linked work items", () -> filterNonTabularLinkedWorkItems(document, selectedRoleEnumValues));
         }
+        timedIfNotNull(generationLog, "Fix tabular linked work items", () -> fixTabularLinkedWorkItems(document));
+        timedIfNotNull(generationLog, "Fix non-tabular linked work items", () -> fixNonTabularLinkedWorkItems(document));
+
         if (exportParams.isCutEmptyWIAttributes()) {
             timedIfNotNull(generationLog, "Cut empty WI attributes", () -> cutEmptyWIAttributes(document));
         }
@@ -702,6 +705,37 @@ public class HtmlProcessor {
                 linkedWorkitemNodesList.get(i).appendComma(); // Separate each group by comma
             } else {
                 linkedWorkitemNodesList.get(i).removeBr(); // Remove br-tag after last group
+            }
+        }
+    }
+
+    private void fixTabularLinkedWorkItems(@NotNull Document document) {
+        Elements linkedWorkItemsCells = document.select("td[id='polarion_editor_field=linkedWorkItems']");
+        for (Element linkedWorkItemsCell : linkedWorkItemsCells) {
+            fixLinkedWorkItems(linkedWorkItemsCell);
+        }
+    }
+
+    private void fixNonTabularLinkedWorkItems(@NotNull Document document) {
+        Elements linkedWorkItemsCells = document.select("span[id='polarion_editor_field=linkedWorkItems']");
+        for (Element linkedWorkItemsCell : linkedWorkItemsCells) {
+            fixLinkedWorkItems(linkedWorkItemsCell);
+        }
+    }
+
+    private void fixLinkedWorkItems(@NotNull Element linkedWorkItemsContainer) {
+        Element nextChild = linkedWorkItemsContainer.firstElementChild();
+
+        while (nextChild != null) {
+            LinkedWorkitemNodes linkedWorkitemNodes = extractLinkedWorkItemNodes(nextChild);
+            if (linkedWorkitemNodes != null) {
+                nextChild = linkedWorkitemNodes.getNextSibling();
+
+                // Role of linked WorkItem is wrapped in div-tag which then takes whole line when converted into DOCX.
+                // We here are changing these divs on spans to allow them to be inlined.
+                linkedWorkitemNodes.roleElement.tagName(HtmlTag.SPAN);
+            } else {
+                nextChild = null;
             }
         }
     }

--- a/src/test/resources/cutLocalUrlsWithRolesFilteringAfterProcessing.html
+++ b/src/test/resources/cutLocalUrlsWithRolesFilteringAfterProcessing.html
@@ -17,17 +17,17 @@
                 </span>
             </span>,
             <span id="polarion_editor_field=linkedWorkItems" onmousedown="return false;" contenteditable="false">
-        <div style="display:inline-block;white-space:nowrap;">
+        <span style="display:inline-block;white-space:nowrap;">
           <span class="polarion-no-style-cleanup" title="Parent - child relationship used to structure items.">has parent</span>
-        </div>
+        </span>
         : <span class="polarion-no-style-cleanup" style="white-space:nowrap;" title="EL-198 - Basic Product Behavior"><span style="white-space:nowrap;"><img src="http://localhost/polarion/icons/default/enums/type_businesscase.gif" class="polarion-Icons" onmousedown="return false;" contenteditable="false" /></span><span style="color:#000000;">EL-198</span><span style="white-space: normal"> - Basic Product Behavior</span></span>,<br />
-        <div style="display:inline-block;white-space:nowrap;">
+        <span style="display:inline-block;white-space:nowrap;">
           <span class="polarion-no-style-cleanup" title="Used to link verifying Test Cases to Requirements, Work Packages or Issues.">is verified by</span>
-        </div>
+        </span>
         : <span class="polarion-no-style-cleanup" style="white-space:nowrap;" title="DP-535 - Login to the portal"><span style="white-space:nowrap;"><img src="http://localhost/polarion/icons/default/enums/type_test.gif" class="polarion-Icons" onmousedown="return false;" contenteditable="false" /></span><span style="color:#C0392B;">DP-535</span><span style="white-space: normal"> - Login to the portal</span></span>,<br />
-        <div style="display:inline-block;white-space:nowrap;">
+        <span style="display:inline-block;white-space:nowrap;">
           <span class="polarion-no-style-cleanup" title="Used to link verifying Test Cases to Issues, Requirements, and User Stories.">is verified by</span>
-        </div>
+        </span>
         : <span class="polarion-no-style-cleanup" style="white-space:nowrap;" title="EL-36 - Open Book Properties"><span style="white-space:nowrap;"><img src="http://localhost/polarion/icons/default/enums/type_test.gif" class="polarion-Icons" onmousedown="return false;" contenteditable="false" /></span><span style="color:#C0392B;">EL-36</span><span style="white-space: normal"> - Open Book Properties</span></span>
             </span>
         </span>

--- a/src/test/resources/linkedWorkItemsAfterProcessing.html
+++ b/src/test/resources/linkedWorkItemsAfterProcessing.html
@@ -19,9 +19,9 @@
                     </span>
                 </span>,
                 <span id="polarion_editor_field=linkedWorkItems" onmousedown="return false;" contenteditable="false">
-                    <div style="display:inline-block;white-space:nowrap;">
+                    <span style="display:inline-block;white-space:nowrap;">
                         <span class="polarion-no-style-cleanup" title="Parent - child relationship used to structure items.">has parent</span>
-                    </div>:
+                    </span>:
                     <span class="polarion-no-style-cleanup" style="white-space:nowrap;" title="EL-3451 - LinkedWorkItems">
                         <a style="font-size:1em;" target="_top" class="polarion-Hyperlink" href="#work-item-anchor-elibrary/EL-3451">
                             <span style="white-space:nowrap;">
@@ -54,9 +54,9 @@
                     </span>
                 </span>,
                 <span id="polarion_editor_field=linkedWorkItems" onmousedown="return false;" contenteditable="false">
-                    <div style="display:inline-block;white-space:nowrap;">
+                    <span style="display:inline-block;white-space:nowrap;">
                         <span class="polarion-no-style-cleanup" title="Parent - child relationship used to structure items.">has parent</span>
-                    </div>:
+                    </span>:
                     <span class="polarion-no-style-cleanup" style="white-space:nowrap;" title="EL-3451 - LinkedWorkItems">
                         <a style="font-size:1em;" target="_top" class="polarion-Hyperlink" href="#work-item-anchor-elibrary/EL-3451">
                             <span style="white-space:nowrap;">

--- a/src/test/resources/linkedWorkItemsTableAfterProcessing.html
+++ b/src/test/resources/linkedWorkItemsTableAfterProcessing.html
@@ -21,9 +21,9 @@
             <tr>
                 <td class="polarion-dle-workitem-fields-end-table-label" onmousedown="return false;" contenteditable="false" style="width:20%">Linked Work Items</td>
                 <td id="polarion_editor_field=linkedWorkItems" class="polarion-dle-workitem-fields-end-table-value" onmousedown="return false;" contenteditable="false" style="width:80%">
-                    <div style="display:inline-block;white-space:nowrap;">
+                    <span style="display:inline-block;white-space:nowrap;">
                         <span class="polarion-no-style-cleanup" title="Parent - child relationship used to structure items.">has parent</span>
-                    </div>
+                    </span>
                     :
                     <span class="polarion-no-style-cleanup" style="white-space:nowrap;" title="EL-3451 - LinkedWorkItems">
                         <a style="font-size:1em;" target="_top" class="polarion-Hyperlink" href="#work-item-anchor-elibrary/EL-3451">
@@ -58,9 +58,9 @@
             <tr>
                 <td class="polarion-dle-workitem-fields-end-table-label" onmousedown="return false;" contenteditable="false" style="width:20%">Linked Work Items</td>
                 <td id="polarion_editor_field=linkedWorkItems" class="polarion-dle-workitem-fields-end-table-value" onmousedown="return false;" contenteditable="false" style="width:80%">
-                    <div style="display:inline-block;white-space:nowrap;">
+                    <span style="display:inline-block;white-space:nowrap;">
                         <span class="polarion-no-style-cleanup" title="Parent - child relationship used to structure items.">has parent</span>
-                    </div>
+                    </span>
                     :
                     <span class="polarion-no-style-cleanup" style="white-space:nowrap;" title="EL-3451 - LinkedWorkItems">
                         <a style="font-size:1em;" target="_top" class="polarion-Hyperlink" href="#work-item-anchor-elibrary/EL-3451">


### PR DESCRIPTION
Fixes #224

### Proposed changes

Role of linked WorkItem was wrapped in div-tag which then takes whole line when converted into DOCX. We are here changing these divs on spans to allow them to be inlined.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
