### PR TITLE
chore: sync from java repo template (49980a2)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@
 name: Claude Code Review
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, ready_for_review, reopened]
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@
 name: CodeQL
 on:
   push:
-    branches: [main]
+    branches: [main, release-v*]
   pull_request:
-    branches: [main]
+    branches: [main, release-v*]
     types: [opened, synchronize, reopened, ready_for_review]
   schedule:
     # Weekly, off-peak Sunday — matches the cadence default setup uses.

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
     services:
       pandoc:
         image: ghcr.io/schweizerischebundesbahnen/pandoc-service:latest@sha256:a3e10842d91807c939d3c91a99d7c5774bade7369c4b4d74560a87820fa77f60  # zizmor: ignore[unpinned-images]
@@ -112,7 +111,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
     env:
       COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_USERNAME: ${{ secrets.COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_USERNAME }}
       COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_TOKEN: ${{ secrets.COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_TOKEN }}
@@ -144,18 +142,59 @@ jobs:
             -Dmaven.wagon.http.connectionTimeout=3600000 \
             -Dmaven.wagon.http.readTimeout=3600000 \
             -Dcentral-publishing-maven-plugin.autoPublish=${{ github.event.repository.visibility == 'public' }}
-  # Deploy to GitHub Packages (snapshots from main only) and upload release assets to GitHub Release
-  # LTS branches (release-v*) only upload release assets, no snapshot deployment
-  deploy-github-packages:
+  # Publish to JFrog Artifactory (sbb.jfrog.io/artifactory/polarion-mvn).
+  # SNAPSHOTs from main always; releases only when the repo is private (public
+  # releases go to Maven Central, see deploy-maven-central). Reuses the artifact
+  # built by the build job via deploy:deploy-file (no rebuild).
+  deploy-jfrog-io:
     needs: build
     if: ${{ github.ref == 'refs/heads/main' || (needs.build.outputs.is_release == 'true' && startsWith(github.ref, 'refs/heads/release-v')) }}
     runs-on: ubuntu-latest
     permissions:
+      contents: read
+    env:
+      IO_JFROG_SBB_POLARION_TOKEN: ${{ secrets.IO_JFROG_SBB_POLARION_TOKEN }}
+      PROJECT_VERSION: ${{ needs.build.outputs.project_version }}
+    steps:
+      - name: 📄 Checkout the repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: 📥 Download build artifacts
+        # The artifacts are generated in the 'build' job
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: maven-artifacts
+          path: target/
+      - name: 🧱 Set up JDK and Maven
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: maven
+      - name: 📦 Deploy to JFrog Artifactory
+        # SNAPSHOTs always; releases only when the repo is private (public releases
+        # go to Maven Central). Main JAR + POM only — sources/javadoc are produced
+        # only for Maven Central releases.
+        if: ${{ needs.build.outputs.is_release == 'false' || github.event.repository.visibility == 'private' }}
+        run: |
+          jar=(target/*-"${PROJECT_VERSION}".jar)
+          mvn --batch-mode -s "${SETTINGS_XML}" deploy:deploy-file \
+            -DrepositoryId=jfrog_io \
+            -Durl=https://sbb.jfrog.io/artifactory/polarion-mvn \
+            -DpomFile=pom.xml \
+            -Dfile="${jar[0]}"
+  # Attach the built JAR to the GitHub Release page. Releases are published to Maven
+  # Central (public repos) or JFrog Artifactory (private repos); SNAPSHOTs go to JFrog.
+  upload-release-assets:
+    needs: build
+    if: ${{ needs.build.outputs.is_release == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-v')) }}
+    runs-on: ubuntu-latest
+    permissions:
       contents: write
-      packages: write
     env:
       GITHUB_TOKEN: ${{ github.token }}
-      GITHUB_REPO_NAME: ${{ github.repository }}
       PROJECT_VERSION: ${{ needs.build.outputs.project_version }}
     steps:
       - name: 📄 Checkout the repository
@@ -169,23 +208,6 @@ jobs:
         with:
           name: maven-artifacts
           path: target/
-      - name: 🧱 Set up JDK and Maven
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
-        with:
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-          java-version: ${{ env.JAVA_VERSION }}
-          cache: maven
-      - name: 📦 Deploy to GitHub Packages
-        # Releases should only be deployed to GitHub Packages when the repo is private
-        # Snapshots are always deployed to GitHub Packages
-        if: ${{ needs.build.outputs.is_release == 'false' || github.event.repository.visibility == 'private' }}
-        run: |
-          mvn --batch-mode -s "${SETTINGS_XML}" deploy \
-            -Dmaven.test.skip=true \
-            -Dmaven.javadoc.skip=true \
-            -Dmaven.source.skip=true \
-            -P deploy-github-packages
       - name: 📦 Upload assets to GitHub Release
-        if: ${{ needs.build.outputs.is_release == 'true' }}
         run: |-
           gh release upload "v${PROJECT_VERSION}" "target/*-${PROJECT_VERSION}.jar" --clobber

--- a/.github/workflows/release-please-guard.yml
+++ b/.github/workflows/release-please-guard.yml
@@ -3,6 +3,11 @@ name: release-please-guard
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  # Runs on Renovate automerge branches so the required "release-please-guard"
+  # check exists on the commit Renovate fast-forwards onto the default branch
+  # (branch automerge pushes directly with no PR).
+  push:
+    branches: [renovate/**]
 permissions: {}
 jobs:
   release-please-guard:

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,11 +1,11 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
     <activeProfiles>
-        <activeProfile>github</activeProfile>
+        <activeProfile>jfrog</activeProfile>
     </activeProfiles>
     <profiles>
         <profile>
-            <id>github</id>
+            <id>jfrog</id>
             <repositories>
                 <repository>
                     <id>jfrog_io</id>
@@ -15,15 +15,13 @@
                         <enabled>true</enabled>
                         <updatePolicy>never</updatePolicy>
                     </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                    </snapshots>
                 </repository>
             </repositories>
             <pluginRepositories/>
-        </profile>
-        <profile>
-            <id>deploy-github-packages</id>
-            <properties>
-                <altDeploymentRepository>github::https://maven.pkg.github.com/${env.GITHUB_REPO_NAME}</altDeploymentRepository>
-            </properties>
         </profile>
     </profiles>
     <servers>
@@ -37,11 +35,6 @@
                     </property>
                 </httpHeaders>
             </configuration>
-        </server>
-        <server>
-            <id>github</id>
-            <username>${env.GITHUB_ACTOR}</username>
-            <password>${env.GITHUB_TOKEN}</password>
         </server>
         <server>
             <id>sonatype-central</id>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@
 
 - **`mvn verify` silently skips the entire Pandoc conversion test suite.** `BasePandocTest` is `@SkipTestWhenParamNotSet` keyed on the `docxExporterImpl` system property, so a plain build reports green without ever running the real HTML→DOCX tests. To actually run them, use `mvn verify -P tests-with-pandoc-docker -Dpandoc.service.url=<url>` (the profile sets `docxExporterImpl=docker`) with a reachable [pandoc-service](https://github.com/SchweizerischeBundesbahnen/pandoc-service) container. This is what CI does.
 
+- **Template-sync: never blind-copy `maven-build.yml` or `renovate.json` from `open-source-polarion-java-repo-template`.** Both carry pandoc-specific config the template lacks, and a verbatim copy silently breaks CI: `maven-build.yml` has the `pandoc` service container plus `-P tests-with-pandoc-docker -Dpandoc.service.url=…` on both `verify` commands; `renovate.json` adds a `customManagers` block tracking `pandoc-service.version`. Hand-merge instead — adopt the template change, re-inject these. The template's GitHub Packages→JFrog publish migration additionally requires hand-aligning `.mvn/settings.xml`, which the sync tooling does not flag as eligible.
+
 - **Base/cross-cutting code is not in this repo.** `ch.sbb.polarion.extension.generic` is the parent project providing reusable infrastructure for all org Polarion plugins — settings framework, REST base classes, security (`@Secured`), OSGi helpers, servlets. Before implementing anything cross-cutting, check whether it already exists in `generic`.
 
 - **After any code change, delete `<polarion_home>/data/workspace/.config` before restarting Polarion** — otherwise the changes are not picked up.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -53,15 +53,17 @@ The `release-v*` pattern in the workflow automatically recognizes new LTS branch
 
 ### Deployment Matrix
 
-| Branch | Version Type | Maven Central | GitHub Packages | GitHub Release |
-|--------|--------------|---------------|-----------------|----------------|
+| Branch | Version Type | Maven Central | JFrog Artifactory | GitHub Release |
+|--------|--------------|---------------|-------------------|----------------|
 | `main` | SNAPSHOT | - | ✓ | - |
-| `main` | Release | ✓ | - | ✓ |
+| `main` | Release | ✓ (public) | ✓ (private only) | ✓ |
 | `release-v*` | SNAPSHOT | - | - | - |
-| `release-v*` | Release | ✓ | - | ✓ |
+| `release-v*` | Release | ✓ (public) | ✓ (private only) | ✓ |
 
 ### Notes
 
-- SNAPSHOT versions from LTS branches are NOT deployed to GitHub Packages
+- SNAPSHOTs are published to JFrog Artifactory (`sbb.jfrog.io/artifactory/polarion-mvn`); publishing to GitHub Packages was removed
+- Releases go to Maven Central for public repositories, or to JFrog Artifactory for private repositories
+- SNAPSHOT versions from LTS branches are NOT deployed anywhere
 - Only release versions from LTS branches are deployed to Maven Central
 - Each LTS branch operates independently with its own release PR


### PR DESCRIPTION
Syncs template drift from `open-source-polarion-java-repo-template`@`49980a2` (2026-06-28).

Closes #267

## Changes

### Workflows (template #154, #156, #161)
- **`claude-code-review.yml`** — drop `synchronize` from PR trigger types (#154).
- **`codeql.yml`** — also run CodeQL on `release-v*` branches (#156).
- **`release-please-guard.yml`** — also run on push to `renovate/**` so the required `release-please-guard` check exists on Renovate automerge fast-forwards (branch automerge pushes directly, no PR) (#161).

### Publish-target migration: GitHub Packages → JFrog Artifactory (template #162)
- **`maven-build.yml`** — replace the `deploy-github-packages` job with `deploy-jfrog-io` (publishes SNAPSHOTs to `sbb.jfrog.io/artifactory/polarion-mvn` via `deploy:deploy-file`) and a dedicated `upload-release-assets` job for GitHub Release assets.
- **`.mvn/settings.xml`** — switch the active resolution profile to `jfrog` (snapshots enabled); drop the now-dead `deploy-github-packages` profile and `github` server.
- **`RELEASE.md`** — update the publish-target table to the JFrog model.

This repo is **public**, so releases continue to publish to **Maven Central** (`deploy-maven-central`); the JFrog job only publishes SNAPSHOTs.

## Hand-merge / preservation notes
- **Pandoc CI test infra preserved** in `maven-build.yml` — the `pandoc` service container, `PANDOC_SERVICE_URL`, and `-P tests-with-pandoc-docker -Dpandoc.service.url=…` on both `verify` invocations are repo-specific and were carried over (not present in the template). The template's verbatim deploy model was adopted around them.
- **Action pins preserved** — `actions/setup-java` (v5.2.0) and `actions/upload-artifact` (v7.0.0) kept at the target's pins; bumps are Renovate's responsibility.

## Intentional divergences (NOT synced)
- **`renovate.json`** — target is a superset (a `customManagers` block tracking `pandoc-service.version` in `versions.properties`); the template has nothing to bring in. Left unchanged.
- **`CLAUDE.md`** — target holds curated, project-specific gotchas; the template's generic bullets do not apply. Left unchanged.

## ⚠ Prerequisite
The new `deploy-jfrog-io` job and the `jfrog_io` server in `settings.xml` require **`IO_JFROG_SBB_POLARION_TOKEN`** to be available to this repo (expected as an org-level secret). It is not set as a repo secret here — confirm org-secret coverage, otherwise SNAPSHOT deploys from `main` will fail. Deploy auth itself is already wired (the `jfrog_io` server pre-existed in `settings.xml`).

## Repo settings
No repo-settings changes were required: CodeQL advanced setup is already active, and the `main-requires-release-please-guard` ruleset already exists.

Synced against `open-source-polarion-java-repo-template`@`49980a2`.