### PR TITLE
ci: pin pandoc-service test container to the tracked version

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -19,7 +19,7 @@ jobs:
       packages: read
     services:
       pandoc:
-        image: ghcr.io/schweizerischebundesbahnen/pandoc-service:latest@sha256:a3e10842d91807c939d3c91a99d7c5774bade7369c4b4d74560a87820fa77f60  # zizmor: ignore[unpinned-images]
+        image: ghcr.io/schweizerischebundesbahnen/pandoc-service:2.2.2@sha256:134a196ce21d5a1562854ea3e08de0e26e0b8be2d4459b5860ae3be7319bb882
         ports: [9082:9082]
     outputs:
       project_version: ${{ steps.project_metadata.outputs.version }}

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -19,7 +19,7 @@ jobs:
       packages: read
     services:
       pandoc:
-        image: ghcr.io/schweizerischebundesbahnen/pandoc-service:2.2.2@sha256:134a196ce21d5a1562854ea3e08de0e26e0b8be2d4459b5860ae3be7319bb882
+        image: ghcr.io/schweizerischebundesbahnen/pandoc-service:2.1.3@sha256:996f28c8b173d623fab80afe2c8141756f1b8ca9a349f99c2df2606d03d7f1e6
         ports: [9082:9082]
     outputs:
       project_version: ${{ steps.project_metadata.outputs.version }}

--- a/renovate.json
+++ b/renovate.json
@@ -16,5 +16,15 @@
       ],
       "versioningTemplate": "semver"
     }
+  ],
+  "packageRules": [
+    {
+      "description": "Keep both pandoc-service references in lockstep: the version in versions.properties (github-releases) and the CI service-container image (docker) update together in one PR",
+      "matchPackageNames": [
+        "SchweizerischeBundesbahnen/pandoc-service",
+        "ghcr.io/schweizerischebundesbahnen/pandoc-service"
+      ],
+      "groupName": "pandoc-service"
+    }
   ]
 }

--- a/src/main/resources/versions.properties
+++ b/src/main/resources/versions.properties
@@ -1,1 +1,1 @@
-pandoc-service.version=2.2.2
+pandoc-service.version=2.1.3


### PR DESCRIPTION
## What

- Pin the CI service container to a concrete pandoc-service **version + digest** (instead of `:latest`), so Renovate version-tracks it.
- Add a Renovate `packageRule` grouping both pandoc-service references — `versions.properties` (github-releases) and the ghcr service image (docker) — under `groupName: "pandoc-service"`, so they bump together in one PR.
- Drop the `# zizmor: ignore[unpinned-images]` suppression — no longer needed with a concrete tag + digest (zizmor passes).

## Test seeding (intentional downgrade)

Both references are pinned **one line below current** at `2.1.3` (current is `2.2.2`) so the first Renovate run after merge demonstrates the grouping end-to-end: a single `pandoc-service` PR should bump **both** back to `2.2.2`, with no 3-day stability wait (the base-preset internal-SBB exemption — `casc-renovate-preset-polarion#2` — is merged). Renovate then re-pins to the current version.

`2.1.3` is used rather than `2.2.0` because **ghcr has no `2.2.0`/`2.2.1` image tag**: those two releases' container builds failed in pandoc-service CI (the linux/arm64 Tectonic bug, issue #176, fixed by #177), so only `2.2.2` — built after the fix — published an image. `2.1.3` exists as both a GitHub release and a concrete image tag.

> Caveat for the future: because image publishing can fail independently of a GitHub release, the two grouped references can occasionally diverge (a release exists with no matching image tag). The grouping at least keeps them in one PR for visibility.

Supersedes #270.

Validated with `renovate-config-validator@latest`; pre-commit (incl. zizmor + actionlint) passes.