### PR TITLE
chore: downgrade pandoc-service to 2.2.0 to test Renovate

### DIFF
--- a/src/main/resources/versions.properties
+++ b/src/main/resources/versions.properties
@@ -1,1 +1,1 @@
-pandoc-service.version=2.2.2
+pandoc-service.version=2.2.0


### PR DESCRIPTION
**Temporary test.** Downgrades `pandoc-service.version` from `2.2.2` to `2.2.0` so that, once merged to `main`, Renovate detects the dependency is behind and raises a bump back to the latest release.

Verifies, now that the base-preset internal-SBB exemption is merged (`casc-renovate-preset-polarion#2`):
- the custom regex manager tracks `SchweizerischeBundesbahnen/pandoc-service` and raises the update, and
- the `^SchweizerischeBundesbahnen/.+-service$` 0-days rule applies (no 3-day stability block).

Once Renovate has bumped it back to `2.2.2`, this test has served its purpose. (Grouping with the CI service image only takes effect after #269 merges.)