### PR TITLE
fix: use Polarion 2606 spinner (progressWheel)

### DIFF
--- a/src/main/resources/webapp/docx-exporter/html/popupForm.html
+++ b/src/main/resources/webapp/docx-exporter/html/popupForm.html
@@ -1,5 +1,5 @@
 <div class="form-wrapper">
-    <div class="docx-in-progress-overlay"><img src='/polarion/ria/images/progress.gif' alt=""/><span id="docx-in-progress-message"></span></div>
+    <div class="docx-in-progress-overlay"><img src='/polarion/ria/images/progressWheel48.svg' alt=""/><span id="docx-in-progress-message"></span></div>
 
     <div class="docx-notifications">
         <div class="alert alert-warning" style="display: none"></div>

--- a/src/main/resources/webapp/docx-exporter/html/sidePanelContent.html
+++ b/src/main/resources/webapp/docx-exporter/html/sidePanelContent.html
@@ -168,7 +168,7 @@
         <button type='button' id='export-docx'>
             <img class='append-build-number' src='/polarion/ria/images/dle/operations/actionMsWordRoundtrip16.svg' alt=''/>Export to DOCX
         </button>
-        <img id='export-docx-progress' src='/polarion/ria/images/progress_grey.gif' alt=''/>
+        <img id='export-docx-progress' src='/polarion/ria/images/progressWheel48.svg' alt=''/>
         <div id='export-docx-error'></div>
         <div id='export-docx-warning'></div>
     </div>


### PR DESCRIPTION
### Proposed changes

Polarion 2606 removed `/polarion/ria/images/progress.gif` (now 404); the export popup loader now uses Polarion's served `progressWheel48.svg`.

Closes #271

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
