### PR TITLE
fix: update render comments IDs in DocxExporter and related files

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/DocxExporterFormExtension.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/DocxExporterFormExtension.java
@@ -186,12 +186,12 @@ public class DocxExporterFormExtension implements IFormExtension {
     @VisibleForTesting
     String adjustRenderComments(String form, StylePackageModel stylePackage) {
         if (stylePackage.getRenderComments() != null) {
-            form = form.replace("<input id='render-comments'", "<input id='render-comments' checked");
-            form = form.replace("id='render-comments-selector' style='display: none'", "id='render-comments-selector'");
+            form = form.replace("<input id='docx-render-comments'", "<input id='docx-render-comments' checked");
+            form = form.replace("id='docx-render-comments-selector' style='display: none'", "id='docx-render-comments-selector'");
             form = form.replace(String.format(OPTION_VALUE, stylePackage.getRenderComments()), String.format(OPTION_SELECTED, stylePackage.getRenderComments()));
-            form = form.replace("id='render-comments-options' style='display: none", "id='render-comments-options' style='display: flex");
+            form = form.replace("id='docx-render-comments-options' style='display: none", "id='docx-render-comments-options' style='display: flex");
             if (stylePackage.isIncludeUnreferencedComments()) {
-                form = form.replace("<input id='include-unreferenced-comments'", "<input id='include-unreferenced-comments' checked");
+                form = form.replace("<input id='docx-include-unreferenced-comments'", "<input id='docx-include-unreferenced-comments' checked");
             }
         }
         return form;

--- a/src/main/resources/webapp/docx-exporter/html/sidePanelContent.html
+++ b/src/main/resources/webapp/docx-exporter/html/sidePanelContent.html
@@ -88,17 +88,17 @@
         </div>
         <div class='property-wrapper'>
             <label>
-                <input id='render-comments' onchange='document.querySelector("#docx-exporter-panel #render-comments-selector").style.display = this.checked ? "block" : "none"; document.querySelector("#docx-exporter-panel #render-comments-options").style.display = this.checked ? "flex" : "none"; if (!this.checked) { document.querySelector("#docx-exporter-panel #include-unreferenced-comments").checked = false; }' type='checkbox'/>
+                <input id='docx-render-comments' onchange='document.querySelector("#docx-exporter-panel #docx-render-comments-selector").style.display = this.checked ? "block" : "none"; document.querySelector("#docx-exporter-panel #docx-render-comments-options").style.display = this.checked ? "flex" : "none"; if (!this.checked) { document.querySelector("#docx-exporter-panel #docx-include-unreferenced-comments").checked = false; }' type='checkbox'/>
                 Comments rendering
             </label>
-            <select id='render-comments-selector' style='display: none'>
+            <select id='docx-render-comments-selector' style='display: none'>
                 <option value='OPEN'>Open</option>
                 <option value='ALL'>All</option>
             </select>
         </div>
-        <div class='property-wrapper' id='render-comments-options' style='display: none; padding-left: 20px'>
-            <label id='include-unreferenced-comments-container' title="Unreferenced comments will be rendered at the end of the document">
-                <input id='include-unreferenced-comments' type='checkbox' />
+        <div class='property-wrapper' id='docx-render-comments-options' style='display: none; padding-left: 20px'>
+            <label id='docx-include-unreferenced-comments-container' title="Unreferenced comments will be rendered at the end of the document">
+                <input id='docx-include-unreferenced-comments' type='checkbox' />
                 include unreferenced
             </label>
         </div>

--- a/src/main/resources/webapp/docx-exporter/js/modules/ExportPanel.js
+++ b/src/main/resources/webapp/docx-exporter/js/modules/ExportPanel.js
@@ -20,7 +20,7 @@ export default class ExportPanel {
         initSearchableDropdowns(this.ctx, [
             'docx-style-package-select', 'docx-template-selector', 'docx-localization-selector',
             'docx-webhooks-selector', 'docx-orientation-selector', 'docx-paper-size-selector',
-            'docx-image-density-selector', 'render-comments-selector', 'docx-language',
+            'docx-image-density-selector', 'docx-render-comments-selector', 'docx-language',
             'docx-link-role-direction'
         ], 'docx-roles-selector');
     }
@@ -67,12 +67,12 @@ export default class ExportPanel {
         this.ctx.setSelector("docx-webhooks-selector", stylePackage.webhooks);
         this.ctx.displayIf("docx-webhooks-selector", !!stylePackage.webhooks, "inline-block")
 
-        this.ctx.setCheckbox("render-comments", !!stylePackage.renderComments);
-        this.ctx.setValue("render-comments-selector", stylePackage.renderComments  || 'OPEN');
-        this.ctx.displayIf("render-comments-selector", !!stylePackage.renderComments);
+        this.ctx.setCheckbox("docx-render-comments", !!stylePackage.renderComments);
+        this.ctx.setValue("docx-render-comments-selector", stylePackage.renderComments  || 'OPEN');
+        this.ctx.displayIf("docx-render-comments-selector", !!stylePackage.renderComments);
 
-        this.ctx.displayIf("render-comments-options", !!stylePackage.renderComments, "flex");
-        this.ctx.setCheckbox("include-unreferenced-comments", !!stylePackage.includeUnreferencedComments);
+        this.ctx.displayIf("docx-render-comments-options", !!stylePackage.renderComments, "flex");
+        this.ctx.setCheckbox("docx-include-unreferenced-comments", !!stylePackage.includeUnreferencedComments);
 
         this.ctx.setCheckbox("docx-cut-empty-chapters", stylePackage.cutEmptyChapters);
         this.ctx.setCheckbox("docx-cut-empty-wi-attributes", stylePackage.cutEmptyWorkitemAttributes);
@@ -159,8 +159,8 @@ export default class ExportPanel {
             .setPreserveTableStyles(this.ctx.getElementById("docx-preserve-table-styles").checked)
             .setWebhooks(this.ctx.getElementById("docx-webhooks-checkbox").checked ? this.ctx.getElementById("docx-webhooks-selector").value : null)
             .setRemovalSelector(this.ctx.getValueById("docx-removal-selector"))
-            .setRenderComments(this.ctx.getElementById('render-comments').checked ? this.ctx.getElementById("render-comments-selector").value : null)
-            .setIncludeUnreferencedComments(this.ctx.getElementById('render-comments').checked && this.ctx.getElementById('include-unreferenced-comments').checked)
+            .setRenderComments(this.ctx.getElementById('docx-render-comments').checked ? this.ctx.getElementById("docx-render-comments-selector").value : null)
+            .setIncludeUnreferencedComments(this.ctx.getElementById('docx-render-comments').checked && this.ctx.getElementById('docx-include-unreferenced-comments').checked)
             .setCutEmptyChapters(this.ctx.getElementById("docx-cut-empty-chapters").checked)
             .setCutEmptyWIAttributes(this.ctx.getElementById('docx-cut-empty-wi-attributes').checked)
             .setCutLocalUrls(this.ctx.getElementById("docx-cut-urls").checked)

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/DocxExporterFormExtensionTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/DocxExporterFormExtensionTest.java
@@ -52,7 +52,7 @@ class DocxExporterFormExtensionTest {
         try (MockedStatic<EnumValuesProvider> mockEnumValuesProvider = mockStatic(EnumValuesProvider.class)) {
             mockEnumValuesProvider.when(() -> EnumValuesProvider.getAllLinkRoleNames(any())).thenReturn(List.of("relates to", "blocks", "duplicates"));
             extension.renderForm(context, module);
-            List<String> expectedEntries = Arrays.asList("someSpecificSelector", "<input id='render-comments' checked", "<input id='docx-orientation' checked", "<input id='docx-paper-size' checked", "<input id='docx-image-density' checked");
+            List<String> expectedEntries = Arrays.asList("someSpecificSelector", "<input id='docx-render-comments' checked", "<input id='docx-orientation' checked", "<input id='docx-paper-size' checked", "<input id='docx-image-density' checked");
             verify(builder, times(0)).html(argThat(arg -> expectedEntries.stream().allMatch(arg::contains)));
 
             stylePackage.setRemovalSelector("someSpecificSelector");
@@ -69,25 +69,25 @@ class DocxExporterFormExtensionTest {
     @Test
     void testAdjustRenderComments() {
         DocxExporterFormExtension extension = new DocxExporterFormExtension();
-        String form = "<input id='render-comments'/>"
-                + "<select id='render-comments-selector' style='display: none'><option value='ALL'></select>"
-                + "<div id='render-comments-options' style='display: none'>"
-                + "<input id='include-unreferenced-comments'/></div>";
+        String form = "<input id='docx-render-comments'/>"
+                + "<select id='docx-render-comments-selector' style='display: none'><option value='ALL'></select>"
+                + "<div id='docx-render-comments-options' style='display: none'>"
+                + "<input id='docx-include-unreferenced-comments'/></div>";
         StylePackageModel packageModel = new StylePackageModel();
         assertThat(extension.adjustRenderComments(form, packageModel)).isEqualTo(form);
 
         packageModel.setRenderComments(CommentsRenderType.ALL);
         assertThat(extension.adjustRenderComments(form, packageModel))
-                .contains("<input id='render-comments' checked")
-                .contains("id='render-comments-options' style='display: flex")
-                .contains("<input id='include-unreferenced-comments'/>")
-                .doesNotContain("<input id='include-unreferenced-comments' checked");
+                .contains("<input id='docx-render-comments' checked")
+                .contains("id='docx-render-comments-options' style='display: flex")
+                .contains("<input id='docx-include-unreferenced-comments'/>")
+                .doesNotContain("<input id='docx-include-unreferenced-comments' checked");
 
         packageModel.setIncludeUnreferencedComments(true);
         assertThat(extension.adjustRenderComments(form, packageModel))
-                .contains("<input id='render-comments' checked")
-                .contains("id='render-comments-options' style='display: flex")
-                .contains("<input id='include-unreferenced-comments' checked");
+                .contains("<input id='docx-render-comments' checked")
+                .contains("id='docx-render-comments-options' style='display: flex")
+                .contains("<input id='docx-include-unreferenced-comments' checked");
     }
 
     @Test


### PR DESCRIPTION
### Proposed changes

- Change IDs for render comments and associated elements to avoid collisions with other components.
- Ensure consistent naming across HTML, JavaScript, and Java files for better maintainability.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
