### PR TITLE
fix: preserve enum icon when localizing enum fields

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessor.java
@@ -506,9 +506,19 @@ public class HtmlProcessor {
         for (Element enumElement : enums) {
             String replacementString = localizationMap.get(enumElement.text());
             if (!StringUtils.isEmptyTrimmed(replacementString)) {
-                enumElement.text(replacementString);
+                replaceEnumLabel(enumElement, replacementString);
             }
         }
+    }
+
+    /**
+     * Replaces the label text of an enum option while preserving child elements such as the
+     * leading enum icon {@code <img>}. Using {@link Element#text(String)} directly would drop
+     * the icon, since it removes all child nodes.
+     */
+    private void replaceEnumLabel(@NotNull Element enumElement, @NotNull String replacement) {
+        enumElement.textNodes().forEach(Node::remove);
+        enumElement.appendText(replacement);
     }
 
     @VisibleForTesting

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessor.java
@@ -512,13 +512,21 @@ public class HtmlProcessor {
     }
 
     /**
-     * Replaces the label text of an enum option while preserving child elements such as the
-     * leading enum icon {@code <img>}. Using {@link Element#text(String)} directly would drop
-     * the icon, since it removes all child nodes.
+     * Replaces the label text of an enum option in place while preserving child elements such as
+     * the leading enum icon {@code <img>}. Using {@link Element#text(String)} directly would drop
+     * the icon, since it removes all child nodes. The localized text keeps the original label's
+     * position: the first text node is updated and any remaining text nodes are removed.
      */
     private void replaceEnumLabel(@NotNull Element enumElement, @NotNull String replacement) {
-        enumElement.textNodes().forEach(Node::remove);
-        enumElement.appendText(replacement);
+        List<TextNode> textNodes = enumElement.textNodes();
+        if (textNodes.isEmpty()) {
+            enumElement.appendText(replacement);
+            return;
+        }
+        textNodes.get(0).text(replacement);
+        for (int i = 1; i < textNodes.size(); i++) {
+            textNodes.get(i).remove();
+        }
     }
 
     @VisibleForTesting

--- a/src/test/resources/localizeEnumsAfterProcessing.html
+++ b/src/test/resources/localizeEnumsAfterProcessing.html
@@ -3,5 +3,6 @@
     <span class="polarion-JSEnumOption" id="sp1">Entwurf</span>
     <span class="polarion-JSEnumOption" id="sp2">Nicht überprüft</span>
     <span class="polarion-JSEnumOption" id="sp3">missing</span>
+    <span class="polarion-JSEnumOption" id="sp4" title="Draft"><img style="vertical-align:bottom;border:0px;margin-right:2px;" src="/polarion/icons/default/enums/req_status_draft.gif" alt=""/>Entwurf</span>
 </p>
 <div>Some div</div>

--- a/src/test/resources/localizeEnumsBeforeProcessing.html
+++ b/src/test/resources/localizeEnumsBeforeProcessing.html
@@ -3,5 +3,6 @@
     <span class="polarion-JSEnumOption" id="sp1">draft</span>
     <span class="polarion-JSEnumOption" id="sp2">not reviewed</span>
     <span class="polarion-JSEnumOption" id="sp3">missing</span>
+    <span class="polarion-JSEnumOption" id="sp4" title="Draft"><img style="vertical-align:bottom;border:0px;margin-right:2px;" src="/polarion/icons/default/enums/req_status_draft.gif" alt="">draft</span>
 </p>
 <div>Some div</div>


### PR DESCRIPTION
### Proposed changes

Localizing an enum label replaced the entire element text, which dropped the leading enum icon `<img>`. When exporting to DOCX with localization enabled, enum fields (e.g. Status) rendered as translated text only, without their icon.

The fix translates only the label text nodes and preserves child elements, so localized exports match the non-localized ones. Ported from pdf-exporter #894.

Closes #284

### Checklist
- [x] I have read the `CONTRIBUTING` document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation