### PR TITLE
fix: keep enum icon order for whitespace-formatted markup

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessor.java
@@ -514,18 +514,25 @@ public class HtmlProcessor {
     /**
      * Replaces the label text of an enum option in place while preserving child elements such as
      * the leading enum icon {@code <img>}. Using {@link Element#text(String)} directly would drop
-     * the icon, since it removes all child nodes. The localized text keeps the original label's
-     * position: the first text node is updated and any remaining text nodes are removed.
+     * the icon, since it removes all child nodes. The localized text replaces the first non-blank
+     * text node (the visible label) in its original position, so it stays after the icon even when
+     * the markup contains formatting whitespace; remaining non-blank text nodes are removed.
      */
     private void replaceEnumLabel(@NotNull Element enumElement, @NotNull String replacement) {
-        List<TextNode> textNodes = enumElement.textNodes();
-        if (textNodes.isEmpty()) {
-            enumElement.appendText(replacement);
-            return;
+        boolean replaced = false;
+        for (TextNode textNode : enumElement.textNodes()) {
+            if (textNode.isBlank()) {
+                continue;
+            }
+            if (replaced) {
+                textNode.remove();
+            } else {
+                textNode.text(replacement);
+                replaced = true;
+            }
         }
-        textNodes.get(0).text(replacement);
-        for (int i = 1; i < textNodes.size(); i++) {
-            textNodes.get(i).remove();
+        if (!replaced) {
+            enumElement.appendText(replacement);
         }
     }
 

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/HtmlProcessorTest.java
@@ -12,6 +12,7 @@ import com.polarion.core.boot.PolarionProperties;
 import lombok.SneakyThrows;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,6 +27,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -370,6 +372,33 @@ class HtmlProcessorTest {
             // Spaces and new lines are removed to exclude difference in space characters
             assertEquals(TestStringUtils.removeNonsensicalSymbols(validHtml), TestStringUtils.removeNonsensicalSymbols(fixedHtml));
         }
+    }
+
+    @Test
+    void localizeEnumsPreservesIconForUncommonTextNodeShapesTest() {
+        Map<String, String> deTranslations = new HashMap<>();
+        deTranslations.put("draft", "Entwurf");
+        deTranslations.put("", "Empty"); // matches an enum option that has no visible label
+        when(localizationSettings.load(anyString(), any(SettingId.class)))
+                .thenReturn(new LocalizationModel(deTranslations, Map.of(), Map.of()));
+
+        // Label split into several text nodes around the icon: the localized value replaces the
+        // first non-blank node and the trailing label node is removed, while the icon is kept.
+        Document splitLabel = JSoupUtils.parseHtml("<span class=\"polarion-JSEnumOption\">dr<img src=\"/icon.gif\"/>aft</span>");
+        processor.localizeEnums(splitLabel, getExportParams());
+        Element splitSpan = splitLabel.selectFirst("span.polarion-JSEnumOption");
+        assertEquals(1, splitSpan.select("img").size());
+        assertEquals("Entwurf", splitSpan.text());
+        assertEquals(1, splitSpan.textNodes().size());
+
+        // Enum option that only carries an icon (no visible label): the localized value is
+        // appended after the icon instead of being dropped.
+        Document iconOnly = JSoupUtils.parseHtml("<span class=\"polarion-JSEnumOption\"><img src=\"/icon.gif\"/></span>");
+        processor.localizeEnums(iconOnly, getExportParams());
+        Element iconSpan = iconOnly.selectFirst("span.polarion-JSEnumOption");
+        assertEquals(1, iconSpan.select("img").size());
+        assertEquals("Empty", iconSpan.text());
+        assertEquals("img", iconSpan.child(0).nodeName());
     }
 
     @Test

--- a/src/test/resources/localizeEnumsAfterProcessing.html
+++ b/src/test/resources/localizeEnumsAfterProcessing.html
@@ -4,5 +4,6 @@
     <span class="polarion-JSEnumOption" id="sp2">Nicht überprüft</span>
     <span class="polarion-JSEnumOption" id="sp3">missing</span>
     <span class="polarion-JSEnumOption" id="sp4" title="Draft"><img style="vertical-align:bottom;border:0px;margin-right:2px;" src="/polarion/icons/default/enums/req_status_draft.gif" alt=""/>Entwurf</span>
+    <span class="polarion-JSEnumOption" id="sp5" title="Draft"><img style="vertical-align:bottom;border:0px;margin-right:2px;" src="/polarion/icons/default/enums/req_status_draft.gif" alt=""/>Entwurf</span>
 </p>
 <div>Some div</div>

--- a/src/test/resources/localizeEnumsBeforeProcessing.html
+++ b/src/test/resources/localizeEnumsBeforeProcessing.html
@@ -4,5 +4,9 @@
     <span class="polarion-JSEnumOption" id="sp2">not reviewed</span>
     <span class="polarion-JSEnumOption" id="sp3">missing</span>
     <span class="polarion-JSEnumOption" id="sp4" title="Draft"><img style="vertical-align:bottom;border:0px;margin-right:2px;" src="/polarion/icons/default/enums/req_status_draft.gif" alt="">draft</span>
+    <span class="polarion-JSEnumOption" id="sp5" title="Draft">
+        <img style="vertical-align:bottom;border:0px;margin-right:2px;" src="/polarion/icons/default/enums/req_status_draft.gif" alt="">
+        draft
+    </span>
 </p>
 <div>Some div</div>


### PR DESCRIPTION
### Proposed changes

Follow-up to #285. `replaceEnumLabel` replaced the *first* text node of the enum span. For whitespace-formatted markup (an icon on its own line, e.g. `<span>\n  <img .../>\n  Draft\n</span>`) the first text node is the blank node **before** the icon, so the localized label was written before the `<img>` and the real label was dropped — rendering label-before-icon.

Now it targets the first **non-blank** text node (the visible label), keeping the label after the icon regardless of formatting whitespace. A new formatted-enum fixture (`sp5`) covers the case.

The same fix is applied to pdf-exporter in SchweizerischeBundesbahnen/ch.sbb.polarion.extension.pdf-exporter#896.

### Checklist
- [x] I have read the `CONTRIBUTING` document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation