### PR TITLE
fix: sync roles multiselect after applying style package

### DIFF
--- a/src/main/resources/webapp/docx-exporter/js/modules/ExportPanel.js
+++ b/src/main/resources/webapp/docx-exporter/js/modules/ExportPanel.js
@@ -112,6 +112,7 @@ export default class ExportPanel {
                 });
             }
         }
+        this.ctx.getElementById("docx-roles-selector")?._searchableDropdown?.syncFromElement();
         this.ctx.displayIf("docx-roles-wrapper", rolesProvided, "flex");
         this.ctx.setValue("docx-link-role-direction", stylePackage.linkRoleDirection || ExportParams.LinkRoleDirection.BOTH);
 

--- a/src/main/resources/webapp/docx-exporter/js/modules/ExportPopup.js
+++ b/src/main/resources/webapp/docx-exporter/js/modules/ExportPopup.js
@@ -306,6 +306,9 @@ export default class ExportPopup {
                 });
             }
         }
+        // Roles were selected via raw option.selected; sync the multiselect widget so its chips
+        // reflect them (the widget only auto-syncs on option add/remove or a 'change' event).
+        this.ctx.getElementById("popup-docx-roles-selector")?._searchableDropdown?.syncFromElement();
         this.ctx.displayIf("popup-docx-roles-selector", rolesProvided, "inline-block");
 
         this.ctx.setValue("popup-docx-link-role-direction", stylePackage.linkRoleDirection || ExportParams.LinkRoleDirection.BOTH);


### PR DESCRIPTION
### Proposed changes

Selecting a style package that carries specific work item roles set the options via raw option.selected on the native `<select>`, which does not update the wrapping SearchableDropdown multiselect widget: it only auto-syncs on option add/remove or a 'change' event. The chosen roles therefore stayed invisible until another combobox change re-rendered it.

Call syncFromElement() on the widget right after selecting the options, in both the export popup and the side panel.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
