### PR TITLE
style: update select dropdown styling and remove color input rules

### DIFF
--- a/src/main/resources/webapp/docx-exporter/css/docx-exporter.css
+++ b/src/main/resources/webapp/docx-exporter/css/docx-exporter.css
@@ -289,7 +289,12 @@
     border-radius: 2px;
 }
 
-.property-wrapper select, .property-wrapper input[type="color"] {
+/* Native <select> dropdown chevron (shared --sbb-combo-chevron). Colour inputs are intentionally NOT
+   matched here: this extension has no colour picker in its document side panel, and this stylesheet is
+   injected into the shared DLE editor — an input[type="color"] rule (worse, with !important) would leak
+   onto sibling extensions' colour fields (e.g. pdf-exporter). The colour-input look is owned by generic
+   inputs.css. */
+.property-wrapper select {
     appearance: none !important;
     -webkit-appearance: none !important;
     -moz-appearance: none !important;
@@ -345,10 +350,6 @@
 
 .modal__container.docx-exporter .property-wrapper select {
     width: 200px;
-}
-
-.property-wrapper input[type="color"] {
-    padding: 2px 2rem 2px 2px;
 }
 
 .buttons-wrapper {


### PR DESCRIPTION
### Proposed changes

This pull request updates the `docx-exporter.css` stylesheet to improve compatibility and avoid style leakage between extensions in the shared DLE editor. The main focus is on refining how styles are applied to `<select>` and `<input type="color">` elements, ensuring that color input styling is not inadvertently applied to other extensions.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
