### PR TITLE
fix: export dialog warnings render unstyled

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ch.sbb.polarion.extensions</groupId>
         <artifactId>ch.sbb.polarion.extension.generic</artifactId>
-        <version>15.3.2</version>
+        <version>15.3.3</version>
     </parent>
 
     <artifactId>ch.sbb.polarion.extension.docx-exporter</artifactId>

--- a/src/main/resources/webapp/docx-exporter/css/docx-exporter.css
+++ b/src/main/resources/webapp/docx-exporter/css/docx-exporter.css
@@ -401,13 +401,15 @@
 }
 
 #export-docx-error, #validate-error, #docx-style-package-error {
-    display: inline-block;
+    display: block;
+    margin-top: 6px;
     color: red;
     font-weight: bold;
 }
 
 #export-docx-warning {
-    display: inline-block;
+    display: block;
+    margin-top: 6px;
     color: orange;
     font-weight: bold;
 }

--- a/src/main/resources/webapp/docx-exporter/css/docx-exporter.css
+++ b/src/main/resources/webapp/docx-exporter/css/docx-exporter.css
@@ -124,30 +124,17 @@
     padding: 0 0 10px;
 }
 
+/* Box padding only; the wrapper carries the extra .notifications class so the box colours (bg/border)
+   and the warning/error triangle icon come from generic alerts.css (.notifications .alert-*). The
+   local .docx-notifications name is kept for the popup's querySelector, which must not match
+   Polarion's own page-level .notifications. */
 .modal__container.docx-exporter .docx-notifications .alert {
     margin-bottom: 10px;
     padding: 6px 12px;
     border-radius: 3px;
 }
 
-.modal__container.docx-exporter .docx-notifications .alert-error {
-    background-color: #f8d7da;
-    border: 1px solid #b3626a;
-}
-
-.modal__container.docx-exporter .docx-notifications .alert-warning {
-    background-color: #fff7cd;
-    border: 1px solid #ffc328;
-}
-
-.modal__container.docx-exporter .docx-notifications .alert-success {
-    background-color: #d1e7dd;
-    border: 1px solid #75b598;
-}
-
-/* Layout only; text colour + weight come from generic .validation-alerts .alert-*.
-   (The notifications box keeps the local .docx-notifications name — and thus its own colour blocks
-   above — to avoid the popup's querySelector matching Polarion's own page-level .notifications.) */
+/* Layout only; text colour + weight come from generic .validation-alerts .alert-*. */
 .modal__container.docx-exporter .validation-alerts {
     display: inline-block;
     padding: 0 10px;

--- a/src/main/resources/webapp/docx-exporter/css/docx-exporter.css
+++ b/src/main/resources/webapp/docx-exporter/css/docx-exporter.css
@@ -389,16 +389,21 @@
 
 #export-docx-error, #validate-error, #docx-style-package-error {
     display: block;
-    margin-top: 6px;
     color: red;
     font-weight: bold;
 }
 
 #export-docx-warning {
     display: block;
-    margin-top: 6px;
     color: orange;
     font-weight: bold;
+}
+
+/* Gap only when a message is actually present — these status divs are empty in the normal state, and
+   an unconditional margin on an empty block would permanently shift the following controls down. */
+#export-docx-error:not(:empty), #validate-error:not(:empty), #docx-style-package-error:not(:empty),
+#export-docx-warning:not(:empty) {
+    margin-top: 6px;
 }
 
 #validate-ok {

--- a/src/main/resources/webapp/docx-exporter/html/popupForm.html
+++ b/src/main/resources/webapp/docx-exporter/html/popupForm.html
@@ -1,7 +1,7 @@
 <div class="form-wrapper">
     <div class="docx-in-progress-overlay"><span class="sbb-spinner" role="img" aria-label="Loading" style="width:48px;height:48px;"></span><span id="docx-in-progress-message"></span></div>
 
-    <div class="docx-notifications">
+    <div class="notifications docx-notifications">
         <div class="alert alert-warning" style="display: none"></div>
         <div class="alert alert-error" style="display: none"></div>
         <div class="alert alert-success" style="display: none"></div>

--- a/src/main/resources/webapp/docx-exporter/js/starter.js
+++ b/src/main/resources/webapp/docx-exporter/js/starter.js
@@ -75,6 +75,7 @@
         generic.injectStyles("generic-checkbox-styles", `${EXT_BASE}ui/generic/css/checkboxes.css${timestampParam}`);
         generic.injectStyles("generic-searchable-dropdown-styles", `${EXT_BASE}ui/generic/css/searchable-dropdown.css${timestampParam}`);
         generic.injectStyles("generic-inputs-styles", `${EXT_BASE}ui/generic/css/inputs.css${timestampParam}`);
+        generic.injectStyles("generic-alerts-styles", `${EXT_BASE}ui/generic/css/alerts.css${timestampParam}`);
         generic.injectScript("docx-micromodal-script", `${EXT_BASE}ui/generic/js/micromodal.min.js${timestampParam}`);
         starter = generic.create({
             markerId: 'docx-exporter-toolbar-injected',


### PR DESCRIPTION
### Proposed changes

This pull request updates the `docx-exporter` extension to improve the consistency and maintainability of notification and alert styling, while also updating a parent dependency version. The main changes involve delegating notification colors and icons to a shared, generic stylesheet, simplifying local CSS, and ensuring consistent alert display in the UI.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
