### PR TITLE
feat: add single-tag dle-toolbar.js injector

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,22 +81,36 @@ ch.sbb.polarion.extension.docx-exporter.pandoc.service=http://localhost:9082
 
 ### DOCX Exporter view to open via button in toolbar
 
-Alternatively you can configure DOCX Exporter such a way that additional toolbar will appear in document's editor with a button to open a popup with DOCX Exporter view.
+Alternatively you can configure DOCX Exporter such a way that a button to open the DOCX Exporter view appears in the document editor's toolbar.
 
 1. Open "Default Repository".
 2. On the top of its navigation pane click ⚙ (Actions) ➙ 🔧 Administration. Global administration page will be opened.
 3. On the administration's navigation pane select Configuration Properties.
 4. In editor of opened page add following line:
    ```properties
-   scriptInjection.dleEditorHead=<script src="/polarion/docx-exporter/js/starter.js"></script><script>DocxExporterStarter.injectToolbar();</script>
+   scriptInjection.dleEditorHead=<script src="/polarion/docx-exporter/js/dle-toolbar.js"></script>
    ```
-   There's an alternate approach adding the DOCX Exporter button into Polarion's native document toolbar. Previously this
-   approach had a drawback — the button could disappear in some cases (for example when the document was saved); this has now
-   been fixed: the button is re-injected automatically when Polarion re-renders the toolbar, so it stays in place:
-   ```properties
-   scriptInjection.dleEditorHead=<script src="/polarion/docx-exporter/js/starter.js"></script><script>DocxExporterStarter.injectToolbar({alternate: true});</script>
-   ```
+   This adds the button into Polarion's native document toolbar. The button is re-injected automatically when Polarion re-renders the toolbar (for example when the document is saved), so it stays in place.
 5. Save changes by clicking 💾 Save
+
+> [!TIP]
+> **Adding more than one toolbar button.** `scriptInjection.dleEditorHead` is a single Polarion-wide property that holds exactly one value. To show several buttons in the document editor (for example the PDF, DOCX and StrictDoc exporters together, or this button alongside any other injected script), do **not** add separate `scriptInjection.dleEditorHead=` lines — the last one overrides the rest. Concatenate all the `<script>` tags into that single value instead:
+> ```properties
+> scriptInjection.dleEditorHead=<script src="/polarion/pdf-exporter/js/dle-toolbar.js"></script><script src="/polarion/docx-exporter/js/dle-toolbar.js"></script><script src="/polarion/strictdoc-exporter/js/dle-toolbar.js"></script>
+> ```
+
+#### Deprecated configuration
+
+The explicit `DocxExporterStarter.injectToolbar(...)` configuration still works but is **deprecated** in favor of the single-tag `dle-toolbar.js` form above (removal is planned for a future major version):
+
+```properties
+# Button in Polarion's native document toolbar — equivalent to the recommended dle-toolbar.js form above.
+scriptInjection.dleEditorHead=<script src="/polarion/docx-exporter/js/starter.js"></script><script>DocxExporterStarter.injectToolbar({alternate: true});</script>
+```
+```properties
+# A separate toolbar with the button placed above the document editing area.
+scriptInjection.dleEditorHead=<script src="/polarion/docx-exporter/js/starter.js"></script><script>DocxExporterStarter.injectToolbar();</script>
+```
 
 ### Configuring logs
 

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/configuration/DleToolbarStatusProvider.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/configuration/DleToolbarStatusProvider.java
@@ -16,33 +16,42 @@ public class DleToolbarStatusProvider extends ConfigurationStatusProvider {
     // Recommended single-tag injector.
     public static final String DLE_TOOLBAR_SCRIPT_REGEX = "(.*)<script src=\"/polarion/docx-exporter/js/dle-toolbar.js[^\"]*\"></script>(.*)";
     // Deprecated explicit-injectToolbar config (still works).
-    public static final String DEPRECATED_DLE_TOOLBAR_SCRIPT_REGEX = "(.*)<script src=\"/polarion/docx-exporter/js/starter.js\"></script>(.*)<script>DocxExporterStarter.injectToolbar(.*);</script>(.*)";
+    public static final String DEPRECATED_DLE_TOOLBAR_SCRIPT_REGEX = "(.*)<script src=\"/polarion/docx-exporter/js/starter.js[^\"]*\"></script>(.*)<script>DocxExporterStarter.injectToolbar(.*);</script>(.*)";
     public static final String NOT_CONFIGURED = "Not configured";
     public static final String DEPRECATED_DETAILS = "Deprecated configuration. Replace it with the single tag "
             + "<script src=\"/polarion/docx-exporter/js/dle-toolbar.js\"></script>";
 
+    // Ordered best-to-worst; when the two property sources disagree the lower ordinal wins.
+    private enum ConfigForm {
+        RECOMMENDED, DEPRECATED, MISSING
+    }
+
     @Override
     public @NotNull ConfigurationStatus getStatus(@NotNull Context context) {
-        ConfigurationStatus systemStatus = classify(ScriptInjectionPropertiesProvider.getScriptInjectionSystemProperties().dleEditorHead());
-        ConfigurationStatus runtimeStatus = classify(ScriptInjectionPropertiesProvider.getScripInjectionRuntimeProperties().dleEditorHead());
-        // Prefer the better-configured of the two property sources (system wins on a tie).
-        return rank(systemStatus) >= rank(runtimeStatus) ? systemStatus : runtimeStatus;
+        ConfigForm system = evaluate(ScriptInjectionPropertiesProvider.getScriptInjectionSystemProperties().dleEditorHead());
+        ConfigForm runtime = evaluate(ScriptInjectionPropertiesProvider.getScripInjectionRuntimeProperties().dleEditorHead());
+        // Prefer the better-configured source (system wins on a tie).
+        return toStatus(system.ordinal() <= runtime.ordinal() ? system : runtime);
     }
 
-    private @NotNull ConfigurationStatus classify(@Nullable String dleEditorHead) {
-        if (dleEditorHead != null && RegexMatcher.get(DLE_TOOLBAR_SCRIPT_REGEX).anyMatch(dleEditorHead)) {
-            return new ConfigurationStatus(DLE_TOOLBAR, Status.OK);
+    private @NotNull ConfigForm evaluate(@Nullable String dleEditorHead) {
+        if (dleEditorHead == null) {
+            return ConfigForm.MISSING;
         }
-        if (dleEditorHead != null && RegexMatcher.get(DEPRECATED_DLE_TOOLBAR_SCRIPT_REGEX).anyMatch(dleEditorHead)) {
-            return new ConfigurationStatus(DLE_TOOLBAR, Status.WARNING, DEPRECATED_DETAILS);
+        if (RegexMatcher.get(DLE_TOOLBAR_SCRIPT_REGEX).anyMatch(dleEditorHead)) {
+            return ConfigForm.RECOMMENDED;
         }
-        return new ConfigurationStatus(DLE_TOOLBAR, Status.WARNING, NOT_CONFIGURED);
+        if (RegexMatcher.get(DEPRECATED_DLE_TOOLBAR_SCRIPT_REGEX).anyMatch(dleEditorHead)) {
+            return ConfigForm.DEPRECATED;
+        }
+        return ConfigForm.MISSING;
     }
 
-    private int rank(@NotNull ConfigurationStatus status) {
-        if (status.getStatus() == Status.OK) {
-            return 2;
-        }
-        return DEPRECATED_DETAILS.equals(status.getDetails()) ? 1 : 0;
+    private @NotNull ConfigurationStatus toStatus(@NotNull ConfigForm form) {
+        return switch (form) {
+            case RECOMMENDED -> new ConfigurationStatus(DLE_TOOLBAR, Status.OK);
+            case DEPRECATED -> new ConfigurationStatus(DLE_TOOLBAR, Status.WARNING, DEPRECATED_DETAILS);
+            case MISSING -> new ConfigurationStatus(DLE_TOOLBAR, Status.WARNING, NOT_CONFIGURED);
+        };
     }
 }

--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/configuration/DleToolbarStatusProvider.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/configuration/DleToolbarStatusProvider.java
@@ -2,22 +2,47 @@ package ch.sbb.polarion.extension.docx_exporter.util.configuration;
 
 import ch.sbb.polarion.extension.generic.configuration.ConfigurationStatus;
 import ch.sbb.polarion.extension.generic.configuration.ConfigurationStatusProvider;
-import ch.sbb.polarion.extension.generic.settings.SettingsService;
+import ch.sbb.polarion.extension.generic.configuration.Status;
+import ch.sbb.polarion.extension.generic.regex.RegexMatcher;
 import ch.sbb.polarion.extension.generic.util.Discoverable;
-import ch.sbb.polarion.extension.generic.util.ScopeUtils;
-import com.polarion.subterra.base.location.ILocation;
+import com.polarion.alm.projects.properties.internal.ScriptInjectionPropertiesProvider;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Discoverable
 public class DleToolbarStatusProvider extends ConfigurationStatusProvider {
 
     public static final String DLE_TOOLBAR = "DLE Toolbar";
+    // Recommended single-tag injector.
+    public static final String DLE_TOOLBAR_SCRIPT_REGEX = "(.*)<script src=\"/polarion/docx-exporter/js/dle-toolbar.js[^\"]*\"></script>(.*)";
+    // Deprecated explicit-injectToolbar config (still works).
+    public static final String DEPRECATED_DLE_TOOLBAR_SCRIPT_REGEX = "(.*)<script src=\"/polarion/docx-exporter/js/starter.js\"></script>(.*)<script>DocxExporterStarter.injectToolbar(.*);</script>(.*)";
+    public static final String NOT_CONFIGURED = "Not configured";
+    public static final String DEPRECATED_DETAILS = "Deprecated configuration. Replace it with the single tag "
+            + "<script src=\"/polarion/docx-exporter/js/dle-toolbar.js\"></script>";
 
     @Override
     public @NotNull ConfigurationStatus getStatus(@NotNull Context context) {
-        ILocation location = ScopeUtils.getDefaultLocation().append(".polarion/context.properties");
-        String content = new SettingsService().read(location, null);
+        ConfigurationStatus systemStatus = classify(ScriptInjectionPropertiesProvider.getScriptInjectionSystemProperties().dleEditorHead());
+        ConfigurationStatus runtimeStatus = classify(ScriptInjectionPropertiesProvider.getScripInjectionRuntimeProperties().dleEditorHead());
+        // Prefer the better-configured of the two property sources (system wins on a tie).
+        return rank(systemStatus) >= rank(runtimeStatus) ? systemStatus : runtimeStatus;
+    }
 
-        return getConfigurationStatus(DLE_TOOLBAR, content, "scriptInjection.dleEditorHead=<script src=\"/polarion/docx-exporter/js/starter.js\"></script>.*<script>DocxExporterStarter.injectToolbar(.*);</script>");
+    private @NotNull ConfigurationStatus classify(@Nullable String dleEditorHead) {
+        if (dleEditorHead != null && RegexMatcher.get(DLE_TOOLBAR_SCRIPT_REGEX).anyMatch(dleEditorHead)) {
+            return new ConfigurationStatus(DLE_TOOLBAR, Status.OK);
+        }
+        if (dleEditorHead != null && RegexMatcher.get(DEPRECATED_DLE_TOOLBAR_SCRIPT_REGEX).anyMatch(dleEditorHead)) {
+            return new ConfigurationStatus(DLE_TOOLBAR, Status.WARNING, DEPRECATED_DETAILS);
+        }
+        return new ConfigurationStatus(DLE_TOOLBAR, Status.WARNING, NOT_CONFIGURED);
+    }
+
+    private int rank(@NotNull ConfigurationStatus status) {
+        if (status.getStatus() == Status.OK) {
+            return 2;
+        }
+        return DEPRECATED_DETAILS.equals(status.getDetails()) ? 1 : 0;
     }
 }

--- a/src/main/resources/webapp/docx-exporter/js/dle-toolbar.js
+++ b/src/main/resources/webapp/docx-exporter/js/dle-toolbar.js
@@ -1,0 +1,34 @@
+/*
+ * One-tag DLE toolbar injector — the simple, recommended way to add the DOCX Exporter button to
+ * Polarion's native document editor toolbar. Configure a single script tag:
+ *
+ *   scriptInjection.dleEditorHead=<script src="/polarion/docx-exporter/js/dle-toolbar.js"></script>
+ *
+ * It loads the thin starter (which pulls the shared self-healing engine) and injects the toolbar
+ * button, so no separate <script>DocxExporterStarter.injectToolbar({alternate: true});</script> tag
+ * is needed. The deprecated explicit-injectToolbar config keeps working; see starter.js.
+ */
+(function () {
+    function injectToolbar() {
+        window.DocxExporterStarter.injectToolbar({alternate: true});
+    }
+
+    // starter.js may already be loaded (e.g. also configured via scriptInjection.mainHead) —
+    // reuse it rather than loading it again.
+    if (window.DocxExporterStarter) {
+        injectToolbar();
+        return;
+    }
+
+    // Load starter.js relative to this script's own URL (…/polarion/<ext>/js/dle-toolbar.js),
+    // so nothing here hardcodes the /polarion/<ext>/ segment.
+    const starterSrc = (document.currentScript && document.currentScript.src || '')
+        .replace(/dle-toolbar\.js.*$/, 'starter.js') || '/polarion/docx-exporter/js/starter.js';
+    const script = document.createElement('script');
+    script.src = starterSrc;
+    script.onload = injectToolbar;
+    script.onerror = function () {
+        console.error("docx-exporter: failed to load starter.js — DLE toolbar button injection skipped.");
+    };
+    document.head.appendChild(script);
+})();

--- a/src/main/resources/webapp/docx-exporter/js/dle-toolbar.js
+++ b/src/main/resources/webapp/docx-exporter/js/dle-toolbar.js
@@ -26,7 +26,13 @@
         .replace(/dle-toolbar\.js.*$/, 'starter.js') || '/polarion/docx-exporter/js/starter.js';
     const script = document.createElement('script');
     script.src = starterSrc;
-    script.onload = injectToolbar;
+    script.onload = function () {
+        if (window.DocxExporterStarter) {
+            injectToolbar();
+        } else {
+            console.error("docx-exporter: starter.js loaded but DocxExporterStarter is not defined — DLE toolbar button injection skipped.");
+        }
+    };
     script.onerror = function () {
         console.error("docx-exporter: failed to load starter.js — DLE toolbar button injection skipped.");
     };

--- a/src/main/resources/webapp/docx-exporter/js/starter.js
+++ b/src/main/resources/webapp/docx-exporter/js/starter.js
@@ -6,6 +6,10 @@
  * The dleEditorHead config is unchanged: it still loads this script and calls
  * DocxExporterStarter.injectToolbar({...}); the bootstrap below pulls the engine and queues
  * the call until it is ready.
+ *
+ * DEPRECATED: the explicit DocxExporterStarter.injectToolbar(...) config is superseded by the
+ * single-tag /polarion/docx-exporter/js/dle-toolbar.js injector (adds the toolbar button without a
+ * second script tag). It keeps working for backward compatibility; removal is a future major bump.
  */
 (function () {
     const timestampParam = `?timestamp=${Date.now()}`;
@@ -49,6 +53,12 @@
     let starter = null, myOrder;
     const pending = [];
     window.DocxExporterStarter = {
+        /**
+         * @deprecated Use the single-tag injector instead:
+         *   <script src="/polarion/docx-exporter/js/dle-toolbar.js"></script>
+         * Kept for backward compatibility; removal is planned for a future major version.
+         * @param {{alternate: boolean}|undefined} params
+         */
         injectToolbar: function (params) {
             if (myOrder === undefined) {
                 // Capture config-execution order (this stub runs synchronously in dleEditorHead

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/configuration/DleToolbarStatusProviderTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/configuration/DleToolbarStatusProviderTest.java
@@ -42,6 +42,7 @@ class DleToolbarStatusProviderTest {
 
         return Stream.of(
                 Arguments.of("", "", notConfigured),
+                Arguments.of(null, null, notConfigured),
 
                 // Recommended single-tag form → OK.
                 Arguments.of(CONFIG_NEW, "", ok),

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/configuration/DleToolbarStatusProviderTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/configuration/DleToolbarStatusProviderTest.java
@@ -1,0 +1,79 @@
+package ch.sbb.polarion.extension.docx_exporter.util.configuration;
+
+import ch.sbb.polarion.extension.generic.configuration.ConfigurationStatus;
+import ch.sbb.polarion.extension.generic.configuration.ConfigurationStatusProvider;
+import ch.sbb.polarion.extension.generic.configuration.Status;
+import com.polarion.alm.projects.properties.internal.ScriptInjectionPropertiesProvider;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mockStatic;
+
+class DleToolbarStatusProviderTest {
+
+    // Recommended single-tag injector.
+    public static final String CONFIG_NEW = "<script src=\"/polarion/docx-exporter/js/dle-toolbar.js\"></script>";
+    // Deprecated explicit-injectToolbar forms (still supported).
+    public static final String CONFIG_DEPRECATED = "<script src=\"/polarion/docx-exporter/js/starter.js\"></script><script>DocxExporterStarter.injectToolbar();</script>";
+    public static final String CONFIG_DEPRECATED_WITH_ALTERNATE = "<script src=\"/polarion/docx-exporter/js/starter.js\"></script><script>DocxExporterStarter.injectToolbar({alternate: true});</script>";
+
+    public static Stream<Arguments> provideConfigurationStatus() {
+        ConfigurationStatus notConfigured = ConfigurationStatus.builder()
+                .name(DleToolbarStatusProvider.DLE_TOOLBAR)
+                .status(Status.WARNING)
+                .details(DleToolbarStatusProvider.NOT_CONFIGURED)
+                .build();
+        ConfigurationStatus ok = ConfigurationStatus.builder()
+                .name(DleToolbarStatusProvider.DLE_TOOLBAR)
+                .status(Status.OK)
+                .details("")
+                .build();
+        ConfigurationStatus deprecated = ConfigurationStatus.builder()
+                .name(DleToolbarStatusProvider.DLE_TOOLBAR)
+                .status(Status.WARNING)
+                .details(DleToolbarStatusProvider.DEPRECATED_DETAILS)
+                .build();
+
+        return Stream.of(
+                Arguments.of("", "", notConfigured),
+
+                // Recommended single-tag form → OK.
+                Arguments.of(CONFIG_NEW, "", ok),
+                Arguments.of("", CONFIG_NEW, ok),
+                Arguments.of(CONFIG_NEW, CONFIG_NEW, ok),
+                Arguments.of("<script></script> <script src=\"/polarion/docx-exporter/js/dle-toolbar.js\"></script> <script></script>", "", ok),
+
+                // Deprecated explicit-injectToolbar forms → WARNING with deprecation hint.
+                Arguments.of(CONFIG_DEPRECATED, "", deprecated),
+                Arguments.of("", CONFIG_DEPRECATED, deprecated),
+                Arguments.of(CONFIG_DEPRECATED_WITH_ALTERNATE, "", deprecated),
+                Arguments.of("", CONFIG_DEPRECATED_WITH_ALTERNATE, deprecated),
+                Arguments.of(CONFIG_DEPRECATED, CONFIG_DEPRECATED, deprecated),
+
+                // The recommended form on either source wins over a deprecated form.
+                Arguments.of(CONFIG_NEW, CONFIG_DEPRECATED, ok),
+                Arguments.of(CONFIG_DEPRECATED, CONFIG_NEW, ok)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideConfigurationStatus")
+    void testConfigurationStatus(String scriptInjectionSystemProperties, String scripInjectionRuntimeProperties, ConfigurationStatus expectedConfigurationStatus) {
+        DleToolbarStatusProvider dleToolbarStatusProvider = new DleToolbarStatusProvider();
+
+        try (MockedStatic<ScriptInjectionPropertiesProvider> scriptInjectionPropertiesProviderMockedStatic = mockStatic(ScriptInjectionPropertiesProvider.class, Mockito.RETURNS_DEEP_STUBS)) {
+            scriptInjectionPropertiesProviderMockedStatic.when(() -> ScriptInjectionPropertiesProvider.getScriptInjectionSystemProperties().dleEditorHead()).thenReturn(scriptInjectionSystemProperties);
+            scriptInjectionPropertiesProviderMockedStatic.when(() -> ScriptInjectionPropertiesProvider.getScripInjectionRuntimeProperties().dleEditorHead()).thenReturn(scripInjectionRuntimeProperties);
+
+            ConfigurationStatusProvider.Context context = ConfigurationStatusProvider.Context.builder().scope("").build();
+            ConfigurationStatus configurationStatus = dleToolbarStatusProvider.getStatus(context);
+            assertEquals(expectedConfigurationStatus, configurationStatus);
+        }
+    }
+}


### PR DESCRIPTION
### Proposed changes

Add a one-tag DLE toolbar injector served at
/polarion/docx-exporter/js/dle-toolbar.js that adds the export button to Polarion's native document toolbar without a second explicit DocxExporterStarter.injectToolbar({alternate: true}) script tag.

The existing starter.js + injectToolbar(...) configuration keeps working but is now deprecated (JSDoc, README, and an About-page validation warning). The DLE toolbar status provider reports the new single-tag form as OK and flags the old two-tag form as a deprecation warning; it now reads the scriptInjection properties the same way as pdf-exporter (system and runtime sources).

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
