### PR TITLE
fix: add wiki velocity tools to velocity evaluator context

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/velocity/VelocityEvaluator.java
+++ b/src/main/java/ch/sbb/polarion/extension/docx_exporter/util/velocity/VelocityEvaluator.java
@@ -8,8 +8,11 @@ import com.polarion.alm.server.api.model.rp.widget.impl.RichPageRenderingContext
 import com.polarion.alm.shared.api.transaction.TransactionalExecutor;
 import com.polarion.alm.shared.api.transaction.internal.InternalReadOnlyTransaction;
 import com.polarion.alm.tracker.model.IModule;
+import com.polarion.alm.wiki.IWikiService;
+import com.polarion.platform.core.PlatformContext;
 import org.apache.velocity.VelocityContext;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.VisibleForTesting;
 
 public class VelocityEvaluator {
 
@@ -18,9 +21,29 @@ public class VelocityEvaluator {
             RichPageRenderingContextImpl richPageRenderingContext = new RichPageRenderingContextImpl((InternalReadOnlyTransaction) transaction);
             RichPageScriptRenderer richPageScriptRenderer = new RichPageScriptRenderer(richPageRenderingContext, template, documentData.getId().getDocumentId());
             VelocityContext velocityContext = richPageScriptRenderer.velocityContext();
+            addWikiRenderingContext(velocityContext);
             updateVelocityContext(velocityContext, documentData);
             return richPageScriptRenderer.renderHtml();
         }));
+    }
+
+    /**
+     * Rich page velocity context, which is used here to evaluate expressions, doesn't contain wiki specific tools
+     * such as $calendarTool or $wikiService, they are contributed to the wiki rendering context only. Without them
+     * expressions which work fine in wiki content are left unevaluated in exported document, so we add them here.
+     * Values already present in the context take precedence and are not overwritten.
+     */
+    @VisibleForTesting
+    void addWikiRenderingContext(@NotNull VelocityContext velocityContext) {
+        IWikiService wikiService = PlatformContext.getPlatform().lookupService(IWikiService.class);
+        if (wikiService == null) {
+            return;
+        }
+        wikiService.getWikiRenderingContextMap().forEach((key, value) -> {
+            if (velocityContext.get(key) == null) {
+                velocityContext.put(key, value);
+            }
+        });
     }
 
     private void updateVelocityContext(@NotNull VelocityContext velocityContext, @NotNull DocumentData<? extends IUniqueObject> documentData) {

--- a/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/velocity/VelocityEvaluatorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/docx_exporter/util/velocity/VelocityEvaluatorTest.java
@@ -1,0 +1,87 @@
+package ch.sbb.polarion.extension.docx_exporter.util.velocity;
+
+import com.polarion.alm.wiki.IWikiService;
+import com.polarion.platform.core.IPlatform;
+import com.polarion.platform.core.PlatformContext;
+import org.apache.velocity.VelocityContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class VelocityEvaluatorTest {
+
+    private VelocityEvaluator velocityEvaluator;
+
+    @BeforeEach
+    void setUp() {
+        velocityEvaluator = new VelocityEvaluator();
+    }
+
+    @Test
+    void addWikiRenderingContextAddsWikiTools() {
+        IWikiService wikiService = mock(IWikiService.class);
+        Object calendarTool = new Object();
+        when(wikiService.getWikiRenderingContextMap()).thenReturn(Map.of("calendarTool", calendarTool));
+
+        VelocityContext velocityContext = new VelocityContext();
+        withWikiService(wikiService, () -> velocityEvaluator.addWikiRenderingContext(velocityContext));
+
+        assertEquals(calendarTool, velocityContext.get("calendarTool"));
+    }
+
+    @Test
+    void addWikiRenderingContextKeepsExistingValues() {
+        IWikiService wikiService = mock(IWikiService.class);
+        when(wikiService.getWikiRenderingContextMap()).thenReturn(Map.of("trackerService", new Object()));
+
+        Object richPageTrackerService = new Object();
+        VelocityContext velocityContext = new VelocityContext();
+        velocityContext.put("trackerService", richPageTrackerService);
+        withWikiService(wikiService, () -> velocityEvaluator.addWikiRenderingContext(velocityContext));
+
+        assertEquals(richPageTrackerService, velocityContext.get("trackerService"));
+    }
+
+    @Test
+    void addWikiRenderingContextSkippedWhenNoWikiService() {
+        VelocityContext velocityContext = new VelocityContext();
+        withWikiService(null, () -> velocityEvaluator.addWikiRenderingContext(velocityContext));
+
+        assertNull(velocityContext.get("calendarTool"));
+    }
+
+    @Test
+    void addWikiRenderingContextDoesNotUseContainsKey() {
+        IWikiService wikiService = mock(IWikiService.class);
+        when(wikiService.getWikiRenderingContextMap()).thenReturn(Map.of("calendarTool", new Object()));
+
+        VelocityContext velocityContext = spy(new VelocityContext());
+        withWikiService(wikiService, () -> velocityEvaluator.addWikiRenderingContext(velocityContext));
+
+        verify(velocityContext, never()).containsKey(any());
+    }
+
+    private void withWikiService(IWikiService wikiService, Runnable runnable) {
+        IPlatform platform = mock(IPlatform.class);
+        when(platform.lookupService(IWikiService.class)).thenReturn(wikiService);
+        try (MockedStatic<PlatformContext> platformContextMockedStatic = mockStatic(PlatformContext.class)) {
+            platformContextMockedStatic.when(PlatformContext::getPlatform).thenReturn(platform);
+            runnable.run();
+        }
+    }
+}


### PR DESCRIPTION
### Proposed changes

Document template and filename expressions are evaluated in the rich page velocity context, which has no wiki specific tools. Expressions like $calendarTool, working fine in wiki content, were therefore left unevaluated in exported document. Wiki rendering context is now merged in, without overwriting values already present.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
