### PR TITLE
chore: inherit markdown2html plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,6 @@
         <maven-jar-plugin.Require-Bundle>${maven-jar-plugin.Require-Bundle.common},${maven-jar-plugin.Require-Bundle.extension}</maven-jar-plugin.Require-Bundle>
 
         <!--suppress UnresolvedMavenProperty -->
-        <markdown2html-maven-plugin.version>1.6.0</markdown2html-maven-plugin.version>
         <markdown2html-maven-plugin.failOnError>${env.MARKDOWN2HTML_MAVEN_PLUGIN_FAIL_ON_ERROR}</markdown2html-maven-plugin.failOnError>
         <markdown2html-maven-plugin.user-guide.inputFile>${project.basedir}/USER_GUIDE.md</markdown2html-maven-plugin.user-guide.inputFile>
         <markdown2html-maven-plugin.user-guide.outputFileName>user-guide.html</markdown2html-maven-plugin.user-guide.outputFileName>


### PR DESCRIPTION
### Proposed changes

The plugin is declared without a version, so it resolves the one from the generic parent's pluginManagement. A local property of the same name overrode that value in the effective pom and pinned the build to 1.6.0 - and renovate never tracked it, because the property carries no version declaration of its own. The plugin could therefore never be updated here.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
