### PR TITLE
fix: keep the shared JSP fragments reachable for the JSP pages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -453,6 +453,39 @@
                 <artifactId>pre-commit-run-maven-plugin</artifactId>
             </plugin>
 
+            <!-- generic.app.jar carries the shared JSP fragments (/common/jsp/notifications.jsp and
+                 friends) that the administration pages include, and it reaches a webapp by being copied
+                 into its WEB-INF/lib. The parent copies it into exactly one webapp -
+                 `generic.app.ui.webapp` - and its vite-ui profile points that at the React app as soon
+                 as ui/ exists. This extension is mid-conversion and serves both UIs, so the JSP webapp
+                 needs its own copy: without it every page still on JSP answers 500 with
+                 "JSP file [/common/jsp/notifications.jsp] not found".
+                 Delete this execution together with the last JSP page. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-generic-app-to-admin-webapp</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>ch.sbb.polarion.extensions</groupId>
+                                    <artifactId>ch.sbb.polarion.extension.generic.app</artifactId>
+                                    <version>${project.parent.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>${basedir}/target/classes/webapp/${maven-jar-plugin.Extension-Context}-admin/WEB-INF/lib</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>


### PR DESCRIPTION
### Proposed changes

Every administration page still served by JSP has been answering **500** since the React app arrived:

```
JSP file [/common/jsp/notifications.jsp] not found
  at org.apache.jsp.pages.style_002dpackages_jsp._jspService(style-packages.jsp:220)
```

Those shared fragments — `notifications.jsp`, `configurations.jsp`, `buttons.jsp` — live inside `generic.app.jar` (`META-INF/resources/common/jsp/…`) and reach a webapp only by being copied into its `WEB-INF/lib`. The parent copies the jar into exactly one webapp, `generic.app.ui.webapp`, and its `vite-ui` profile repoints that from the JSP webapp to the React one as soon as `ui/` exists — on the reasonable assumption that a converted extension no longer has a JSP webapp. That assumption does not hold here: the conversion is page by page, both UIs are served at once, and the JSP webapp quietly lost the fragments its pages include.

So the jar is copied into it explicitly. The execution is transitional and says so in a comment: it goes away together with the last JSP page.

Not a regression from any one PR to revert — it started the moment `ui/` appeared, which is why it is fixed on `main` rather than inside a conversion branch.

**Verified in a running Polarion** (build → deploy → restart → open each page in a browser): every remaining JSP page renders again, HTTP 200.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
